### PR TITLE
🧪 add testing coverage for load_last_line generic exception

### DIFF
--- a/Analysis/tests/test_signal_dashboard.py
+++ b/Analysis/tests/test_signal_dashboard.py
@@ -1,0 +1,51 @@
+import pytest
+from unittest.mock import patch, mock_open
+from pathlib import Path
+import json
+
+from Analysis.signal_dashboard import load_last_line
+
+def test_load_last_line_not_exists():
+    """Test when the file does not exist."""
+    filepath = Path("nonexistent.jsonl")
+    with patch.object(Path, 'exists', return_value=False):
+        result = load_last_line(filepath)
+        assert result is None
+
+def test_load_last_line_success():
+    """Test successful loading of the last line."""
+    filepath = Path("dummy.jsonl")
+    file_content = '{"key1": "value1"}\n{"key2": "value2"}\n'
+
+    with patch.object(Path, 'exists', return_value=True):
+        with patch('builtins.open', mock_open(read_data=file_content)):
+            result = load_last_line(filepath)
+            assert result == {"key2": "value2"}
+
+def test_load_last_line_empty_file():
+    """Test loading from an empty file."""
+    filepath = Path("dummy.jsonl")
+
+    with patch.object(Path, 'exists', return_value=True):
+        with patch('builtins.open', mock_open(read_data="")):
+            result = load_last_line(filepath)
+            assert result is None
+
+def test_load_last_line_invalid_json():
+    """Test loading when the last line is invalid JSON."""
+    filepath = Path("dummy.jsonl")
+    file_content = '{"key1": "value1"}\ninvalid json\n'
+
+    with patch.object(Path, 'exists', return_value=True):
+        with patch('builtins.open', mock_open(read_data=file_content)):
+            result = load_last_line(filepath)
+            assert result is None
+
+def test_load_last_line_generic_exception():
+    """Test that load_last_line handles generic exceptions during file read."""
+    filepath = Path("dummy.jsonl")
+
+    with patch.object(Path, 'exists', return_value=True):
+        with patch('builtins.open', side_effect=Exception("Simulated read error")):
+            result = load_last_line(filepath)
+            assert result is None


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The `load_last_line` function in `Analysis/signal_dashboard.py` handles generic exceptions silently (e.g., file read errors) by returning `None`, but this path lacked testing.

📊 **Coverage:** What scenarios are now tested
Added a complete unit test suite in `Analysis/tests/test_signal_dashboard.py` covering:
- Simulating a file read exception (`Exception`) during `open` (the specific task goal)
- `load_last_line` on non-existent files
- `load_last_line` on valid JSONL files
- `load_last_line` on empty files
- `load_last_line` with invalid JSON strings on the last line

✨ **Result:** The improvement in test coverage
The exception block of `load_last_line` and all edge cases of file handling in this function are fully covered, ensuring no regressions.

---
*PR created automatically by Jules for task [13747377609239309281](https://jules.google.com/task/13747377609239309281) started by @MattRbear*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 7a105b92fc649a0a984f542a19bae271839b0646. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Summary by Sourcery

Add unit tests to fully cover load_last_line behavior in signal_dashboard file handling edge cases and exceptions.

Tests:
- Add tests for load_last_line when the file does not exist, is empty, or contains invalid JSON on the last line.
- Add tests for load_last_line successful reads of the last JSONL line.
- Add tests verifying load_last_line returns None on generic exceptions raised during file read.