### PR TITLE
🧹 Refactor extract_from_json to reduce nested complexity

### DIFF
--- a/extract_nova_chat.py
+++ b/extract_nova_chat.py
@@ -216,6 +216,41 @@ def match_topics(text: str) -> tuple[Set[str], float]:
 # RECORD EXTRACTORS
 # ============================================================================
 
+def _extract_json_list(data: list, filepath: Path, input_root: Path) -> Iterator[Dict[str, Any]]:
+    """Helper to extract records from a JSON list."""
+    for idx, item in enumerate(data):
+        if isinstance(item, dict):
+            yield format_record(item, filepath, input_root, 'openai_export_json', idx)
+        elif isinstance(item, str):
+            yield {
+                'text': item,
+                'source_file': str(filepath.relative_to(input_root)),
+                'detected_format': 'json_array',
+                'message_index': idx
+            }
+
+def _extract_json_messages(data: dict, filepath: Path, input_root: Path) -> Iterator[Dict[str, Any]]:
+    """Helper to extract records from a JSON dict containing 'messages'."""
+    messages = data['messages']
+    conv_id = data.get('id') or data.get('conversation_id')
+    for idx, msg in enumerate(messages):
+        record = format_record(msg, filepath, input_root, 'openai_export_json', idx)
+        if conv_id:
+            record['conversation_id'] = conv_id
+        yield record
+
+def _extract_json_conversations(data: dict, filepath: Path, input_root: Path) -> Iterator[Dict[str, Any]]:
+    """Helper to extract records from a JSON dict containing 'conversations'."""
+    for conv in data['conversations']:
+        conv_id = conv.get('id')
+        messages = conv.get('messages', [])
+        for idx, msg in enumerate(messages):
+            record = format_record(msg, filepath, input_root, 'openai_export_json', idx)
+            if conv_id:
+                record['conversation_id'] = conv_id
+            yield record
+
+
 def extract_from_json(filepath: Path, input_root: Path) -> Iterator[Dict[str, Any]]:
     """Extract records from JSON file."""
     try:
@@ -227,38 +262,15 @@ def extract_from_json(filepath: Path, input_root: Path) -> Iterator[Dict[str, An
         
         # Try to detect structure
         if isinstance(data, list):
-            # Array of messages
-            for idx, item in enumerate(data):
-                if isinstance(item, dict):
-                    yield format_record(item, filepath, input_root, 'openai_export_json', idx)
-                elif isinstance(item, str):
-                    yield {
-                        'text': item,
-                        'source_file': str(filepath.relative_to(input_root)),
-                        'detected_format': 'json_array',
-                        'message_index': idx
-                    }
+            yield from _extract_json_list(data, filepath, input_root)
         
         elif isinstance(data, dict):
             # Check for common chat export structures
             if 'messages' in data:
-                messages = data['messages']
-                conv_id = data.get('id') or data.get('conversation_id')
-                for idx, msg in enumerate(messages):
-                    record = format_record(msg, filepath, input_root, 'openai_export_json', idx)
-                    if conv_id:
-                        record['conversation_id'] = conv_id
-                    yield record
+                yield from _extract_json_messages(data, filepath, input_root)
             
             elif 'conversations' in data:
-                for conv in data['conversations']:
-                    conv_id = conv.get('id')
-                    messages = conv.get('messages', [])
-                    for idx, msg in enumerate(messages):
-                        record = format_record(msg, filepath, input_root, 'openai_export_json', idx)
-                        if conv_id:
-                            record['conversation_id'] = conv_id
-                        yield record
+                yield from _extract_json_conversations(data, filepath, input_root)
             
             else:
                 # Fallback: extract any text-like fields


### PR DESCRIPTION
🎯 **What:** Extracted nested `if/elif/else` JSON parsing logic inside `extract_nova_chat.py`'s `extract_from_json` function into dedicated helper functions (`_extract_json_list`, `_extract_json_messages`, `_extract_json_conversations`).
💡 **Why:** Reduces nesting from 4+ levels to 2 levels, improving readability and clarifying the distinct JSON export structures being parsed.
✅ **Verification:** Ran `python extract_nova_chat.py --input a --output b --self-test` to ensure standard parsing chunks correctly, with no deviation in the number of records kept or dropped.
✨ **Result:** A more maintainable and readable `extract_from_json` routine that acts as a clean router to more specific extraction subroutines via `yield from`.

---
*PR created automatically by Jules for task [16107681532259671699](https://jules.google.com/task/16107681532259671699) started by @MattRbear*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that should be behavior-preserving; main risk is subtle record-shape differences if any helper diverges from the previous inlined logic.
> 
> **Overview**
> Refactors `extract_from_json` to reduce nesting by routing JSON structures through three new helper generators: `_extract_json_list`, `_extract_json_messages`, and `_extract_json_conversations`.
> 
> Behavior is intended to stay the same (same record formatting and conversation ID propagation), but the control flow now uses `yield from` to delegate extraction for each detected JSON export shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 066f6625a69eba7d6ab6ce99318b417b92024d70. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Summary by Sourcery

Enhancements:
- Extract JSON list, messages, and conversations parsing into dedicated helper functions to reduce nesting and improve readability in extract_from_json.