### PR TITLE
🧹 Refactor: Extract deeply nested CVD trade cursor logic

### DIFF
--- a/CVD/run_cvd_from_jsonl.py
+++ b/CVD/run_cvd_from_jsonl.py
@@ -126,6 +126,23 @@ def read_trade_files(symbol: str) -> List[Path]:
     return files
 
 
+def _is_new_trade(trade: Trade, state: CVDState) -> bool:
+    """Check if the trade is strictly after the state cursor."""
+    if state.last_timestamp_utc is None:
+        return True
+
+    if trade.timestamp_utc < state.last_timestamp_utc:
+        return False
+
+    if trade.timestamp_utc == state.last_timestamp_utc:
+        # Same timestamp - check trade_id (numeric comparison)
+        if state.last_trade_id is not None:
+            if int(trade.trade_id) <= int(state.last_trade_id):
+                return False
+
+    return True
+
+
 def parse_trades(filepath: Path, state: CVDState) -> List[Trade]:
     """
     Read trades from JSONL file.
@@ -142,15 +159,8 @@ def parse_trades(filepath: Path, state: CVDState) -> List[Trade]:
             trade = Trade(**data)
             
             # Skip if before or equal to cursor
-            if state.last_timestamp_utc is not None:
-                if trade.timestamp_utc < state.last_timestamp_utc:
-                    continue
-                
-                if trade.timestamp_utc == state.last_timestamp_utc:
-                    # Same timestamp - check trade_id (numeric comparison)
-                    if state.last_trade_id is not None:
-                        if int(trade.trade_id) <= int(state.last_trade_id):
-                            continue
+            if not _is_new_trade(trade, state):
+                continue
             
             trades.append(trade)
     


### PR DESCRIPTION
🎯 **What:** Extracted the 5-level deep nested `if` statements that check if a trade is after the CVD State cursor into a clean helper function `_is_new_trade`.
💡 **Why:** Reduces cognitive complexity and cyclomatic complexity in the `parse_trades` function, flattening the inner parsing loop and making it easier to read and maintain.
✅ **Verification:** Verified syntax manually and tested via a custom `test_is_new_trade.py` script mirroring the logic, confirming identical logic handling for missing state, older timestamps, exact timestamp collisions, and newer timestamps. Cleaned up `__pycache__` artifacts prior to submission.
✨ **Result:** Improved readability and testability of the CVD calculation pipeline without altering program behavior.

---
*PR created automatically by Jules for task [8653927525387842169](https://jules.google.com/task/8653927525387842169) started by @MattRbear*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 84ac55464b38c1af44e6ea299e0b43b266802374. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Summary by Sourcery

Enhancements:
- Introduce an `_is_new_trade` helper to encapsulate cursor-based trade filtering and reduce complexity in `parse_trades`.