### PR TITLE
🧪 [Testing Improvement] Add tests for load_metadata

### DIFF
--- a/Liquidity_Buckets/test_l2_bucketizer.py
+++ b/Liquidity_Buckets/test_l2_bucketizer.py
@@ -1,0 +1,72 @@
+import pytest
+import json
+from pathlib import Path
+
+from Liquidity_Buckets.l2_bucketizer import load_metadata
+
+def test_load_metadata_file_not_found(tmp_path, monkeypatch):
+    """Test that load_metadata raises FileNotFoundError when metadata file is missing."""
+    # Mock VAULT_BASE to use our temporary directory
+    monkeypatch.setattr('Liquidity_Buckets.l2_bucketizer.VAULT_BASE', tmp_path)
+
+    with pytest.raises(FileNotFoundError, match="Metadata not found for BTC-USDT-SWAP"):
+        load_metadata("BTC-USDT-SWAP")
+
+def test_load_metadata_with_normalized(tmp_path, monkeypatch):
+    """Test loading metadata when 'normalized' key is present."""
+    monkeypatch.setattr('Liquidity_Buckets.l2_bucketizer.VAULT_BASE', tmp_path)
+
+    # Setup mock file structure
+    meta_dir = tmp_path / 'meta' / 'okx' / 'instruments'
+    meta_dir.mkdir(parents=True)
+    meta_file = meta_dir / 'BTC-USDT-SWAP.json'
+
+    # Write mock data
+    mock_data = {
+        "normalized": {"ctVal": "0.01"},
+        "raw": {"other": "data"}
+    }
+    meta_file.write_text(json.dumps(mock_data))
+
+    # Call function and assert result
+    result = load_metadata("BTC-USDT-SWAP")
+    assert result == {"ctVal": "0.01"}
+
+def test_load_metadata_with_raw_fallback(tmp_path, monkeypatch):
+    """Test loading metadata falling back to 'raw' key when 'normalized' is missing."""
+    monkeypatch.setattr('Liquidity_Buckets.l2_bucketizer.VAULT_BASE', tmp_path)
+
+    # Setup mock file structure
+    meta_dir = tmp_path / 'meta' / 'okx' / 'instruments'
+    meta_dir.mkdir(parents=True)
+    meta_file = meta_dir / 'BTC-USDT-SWAP.json'
+
+    # Write mock data without 'normalized' key
+    mock_data = {
+        "raw": {"ctVal": "0.01", "other": "data"}
+    }
+    meta_file.write_text(json.dumps(mock_data))
+
+    # Call function and assert result
+    result = load_metadata("BTC-USDT-SWAP")
+    assert result == {"ctVal": "0.01", "other": "data"}
+
+def test_load_metadata_with_top_level_fallback(tmp_path, monkeypatch):
+    """Test loading metadata falling back to top-level data when neither 'normalized' nor 'raw' is present."""
+    monkeypatch.setattr('Liquidity_Buckets.l2_bucketizer.VAULT_BASE', tmp_path)
+
+    # Setup mock file structure
+    meta_dir = tmp_path / 'meta' / 'okx' / 'instruments'
+    meta_dir.mkdir(parents=True)
+    meta_file = meta_dir / 'BTC-USDT-SWAP.json'
+
+    # Write mock data without 'normalized' or 'raw' keys
+    mock_data = {
+        "ctVal": "0.01",
+        "instType": "SWAP"
+    }
+    meta_file.write_text(json.dumps(mock_data))
+
+    # Call function and assert result
+    result = load_metadata("BTC-USDT-SWAP")
+    assert result == {"ctVal": "0.01", "instType": "SWAP"}


### PR DESCRIPTION
🎯 **What:** The testing gap addressed for `load_metadata` in `Liquidity_Buckets/l2_bucketizer.py`
  📊 **Coverage:** Covered missing file scenarios (`FileNotFoundError`) and valid JSON loading paths with different fallback structures (`normalized`, `raw`, top-level) using pytest `tmp_path` and `monkeypatch`.
  ✨ **Result:** Improved test coverage and codebase reliability.

---
*PR created automatically by Jules for task [16303674672233428942](https://jules.google.com/task/16303674672233428942) started by @MattRbear*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because changes are test-only; the main risk is brittle assumptions about the `VAULT_BASE/meta/okx/instruments` path and JSON shape expectations in `load_metadata`.
> 
> **Overview**
> Adds a new pytest suite for `Liquidity_Buckets.l2_bucketizer.load_metadata`, covering the missing-metadata `FileNotFoundError` case and the JSON selection behavior across `normalized`, `raw`, and top-level fallback structures using `tmp_path` + `monkeypatch`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58b981029de81e18ab0a5f95c16636cea6e61dbe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Summary by Sourcery

Tests:
- Add pytest-based tests covering missing metadata files and multiple metadata JSON structures for load_metadata.