### PR TITLE
🧹 Refactor deeply nested logic in VWAP parse_trades

### DIFF
--- a/VWAP/vwap_calculator.py
+++ b/VWAP/vwap_calculator.py
@@ -330,6 +330,22 @@ def read_trade_files(inst_id: str) -> List[Path]:
     return files
 
 
+def _is_new_trade(trade: Trade, state: VWAPState) -> bool:
+    """Check if trade is after the state cursor."""
+    if state.last_timestamp_utc is None:
+        return True
+
+    if trade.timestamp_utc < state.last_timestamp_utc:
+        return False
+
+    if trade.timestamp_utc == state.last_timestamp_utc:
+        if state.last_trade_id is not None:
+            if trade.trade_id <= state.last_trade_id:
+                return False
+
+    return True
+
+
 def parse_trades(filepath: Path, state: VWAPState) -> List[Trade]:
     """
     Read trades from JSONL file.
@@ -354,16 +370,8 @@ def parse_trades(filepath: Path, state: VWAPState) -> List[Trade]:
                 logger.warning(f"Skipping invalid trade data at line {line_num}: {e}")
                 continue
             
-            # Skip if before or equal to cursor
-            if state.last_timestamp_utc is not None:
-                if trade.timestamp_utc < state.last_timestamp_utc:
-                    continue
-                
-                if trade.timestamp_utc == state.last_timestamp_utc:
-                    # Same timestamp - check trade_id
-                    if state.last_trade_id is not None:
-                        if trade.trade_id <= state.last_trade_id:
-                            continue
+            if not _is_new_trade(trade, state):
+                continue
             
             trades.append(trade)
     


### PR DESCRIPTION
🎯 **What:** The deeply nested `if` statements in `parse_trades` within `VWAP/vwap_calculator.py` were extracted into a new helper function called `_is_new_trade`.

💡 **Why:** This refactoring improves the readability and maintainability of `parse_trades` by replacing multiple layers of nesting with a single, clear conditional statement.

✅ **Verification:** Ran `python VWAP/vwap_calculator.py --instId BTC-USDT-SWAP` and executed the pytest suite (`PYTHONPATH=. pytest`) to ensure no syntax or logical errors were introduced. Requested and received a code review which passed cleanly as `#Correct#`.

✨ **Result:** The code health of `VWAP/vwap_calculator.py` is improved without altering the exact logical conditions needed to filter out processed trades.

---
*PR created automatically by Jules for task [889711401409851027](https://jules.google.com/task/889711401409851027) started by @MattRbear*

## Summary by Sourcery

Enhancements:
- Extract trade cursor comparison logic from parse_trades into a reusable _is_new_trade helper to simplify control flow and improve readability.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that only reorganizes the existing trade deduplication/cursor comparison logic into `_is_new_trade` without changing VWAP calculations or I/O.
> 
> **Overview**
> Refactors `VWAP/vwap_calculator.py` by extracting the “is this trade after the last processed cursor?” checks from `parse_trades` into a new `_is_new_trade(trade, state)` helper.
> 
> `parse_trades` now uses a single guard (`if not _is_new_trade(...): continue`) instead of nested conditionals, improving readability while keeping the same cursor semantics (`timestamp_utc` then `trade_id`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 598b97f0e77347ad10d8367643a5859a1f15d47d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->