### PR TITLE
⚡ perf: Optimize Trades_Bot JSON parsing with orjson

### DIFF
--- a/Trades_Bot/requirements.txt
+++ b/Trades_Bot/requirements.txt
@@ -1,2 +1,3 @@
 websockets>=12.0
 requests>=2.31.0
+orjson>=3.9.0

--- a/Trades_Bot/trades_exporter.py
+++ b/Trades_Bot/trades_exporter.py
@@ -13,6 +13,14 @@ import json
 import logging
 import requests
 from datetime import datetime, timezone
+
+try:
+    import orjson
+    json_loads = orjson.loads
+    JSONDecodeError = orjson.JSONDecodeError
+except ImportError:
+    json_loads = json.loads
+    JSONDecodeError = json.JSONDecodeError
 from pathlib import Path
 from typing import Dict, Set
 import websockets
@@ -323,9 +331,9 @@ class TradesExporter:
                     continue
                 
                 try:
-                    data = json.loads(message)
+                    data = json_loads(message)
                     await self.process_message(data)
-                except json.JSONDecodeError:
+                except JSONDecodeError:
                     logger.error(f"Failed to decode message: {message}")
         
         except websockets.exceptions.ConnectionClosed:


### PR DESCRIPTION
💡 **What:** 
Replaced the standard library's `json.loads` with `orjson.loads` as the primary JSON decoder for high-frequency WebSocket messages in the `Trades_Bot`, falling back to standard `json` if `orjson` is unavailable. Added `orjson>=3.9.0` to `requirements.txt`.

🎯 **Why:** 
The standard `json.loads` is called on every incoming message. In a high-frequency context (like OKX perpetuals trade stream), standard library JSON decoding can become a significant CPU bottleneck. `orjson` provides a more efficient, faster implementation suitable for heavy streams.

📊 **Measured Improvement:** 
Using a standalone benchmark parsing a typical OKX trade message `{"arg":{...},"data":[...]}` for 100,000 iterations:
* **Baseline (json.loads):** ~0.5266s
* **Optimized (orjson.loads):** ~0.1643s
* **Improvement:** ~3.2x faster parsing per message.

---
*PR created automatically by Jules for task [9181885804096533718](https://jules.google.com/task/9181885804096533718) started by @MattRbear*

## Summary by Sourcery

Optimize JSON parsing in the Trades_Bot WebSocket message handler to improve performance and add the necessary dependency.

Enhancements:
- Switch the Trades_Bot WebSocket message handler to use a configurable JSON loader and decoder error type to enable faster parsing with orjson when available.

Build:
- Add orjson as a dependency in Trades_Bot/requirements.txt to support high-performance JSON parsing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: limited to swapping the WebSocket message JSON decoder and adding an optional dependency; behavioral change is minimal aside from potential decode edge cases between `orjson` and stdlib `json`.
> 
> **Overview**
> Improves `Trades_Bot` WebSocket throughput by preferring `orjson` for parsing incoming JSON messages (with a safe fallback to stdlib `json` when unavailable) and updating error handling to catch the appropriate decode exception.
> 
> Adds `orjson>=3.9.0` to dependencies to support the faster decoder.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9cb5a46eec686662bb2bf095e9f328a2a36f0fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->