### PR TITLE
🧪 test: add unit tests for validate_environment

### DIFF
--- a/config/test_validation.py
+++ b/config/test_validation.py
@@ -1,0 +1,23 @@
+import unittest
+from unittest.mock import patch
+from config.validation import validate_environment
+
+class TestValidation(unittest.TestCase):
+
+    @patch.dict('os.environ', {'COINALYZE_API_KEY': 'dummy_key'}, clear=True)
+    def test_validate_environment_success(self):
+        is_valid, messages = validate_environment()
+        self.assertTrue(is_valid)
+        self.assertEqual(messages, [])
+
+    @patch.dict('os.environ', {}, clear=True)
+    def test_validate_environment_missing_key(self):
+        is_valid, messages = validate_environment()
+        self.assertFalse(is_valid)
+        self.assertGreaterEqual(len(messages), 1)
+        # Check for presence of the required key in the error messages.
+        found_message = any("COINALYZE_API_KEY" in msg for msg in messages)
+        self.assertTrue(found_message)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Adds unit testing for the `validate_environment` function located in `config/validation.py:10`. The tests use `unittest.mock.patch.dict` to simulate changes to `os.environ` providing coverage for both the success scenario and the failure scenario when required keys are missing.

---
*PR created automatically by Jules for task [14624938015670692013](https://jules.google.com/task/14624938015670692013) started by @MattRbear*

## Summary by Sourcery

Tests:
- Introduce unit tests for `validate_environment` covering success and missing-required-key scenarios using patched environment variables.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new `unittest` file only, with no production logic changes.
> 
> **Overview**
> Adds `config/test_validation.py` with `unittest` coverage for `validate_environment`, validating both a success case when `COINALYZE_API_KEY` is set and a failure case when it’s missing via `patch.dict(os.environ)`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 684e4fe92a3427daf433993781b1d225577958cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->