### PR TITLE
Refactor codebase to fix Windows paths and python string escape sequences

### DIFF
--- a/Analysis/confluence_analyzer.py
+++ b/Analysis/confluence_analyzer.py
@@ -11,16 +11,17 @@ Reads all data sources and identifies max conviction setups where:
 Outputs ranked trade signals with conviction scores.
 
 INPUT:
-- Vault\derived\wicks\okx\perps\{INSTID}\wicks_events.jsonl
-- Vault\derived\volume\okx\perps\{INSTID}\volume_1m.jsonl
-- Vault\derived\liquidity_buckets\okx\perps\{INSTID}\{DATE}.jsonl
-- Vault\derived\cvd\okx\perps\{INSTID}\cvd_1m.jsonl
-- Vault\derived\vwap\okx\perps\{INSTID}\vwap_1m.jsonl
+- Vault\\derived\\wicks\\okx\\perps\\{INSTID}\\wicks_events.jsonl
+- Vault\\derived\\volume\\okx\\perps\\{INSTID}\\volume_1m.jsonl
+- Vault\\derived\\liquidity_buckets\\okx\\perps\\{INSTID}\\{DATE}.jsonl
+- Vault\\derived\\cvd\\okx\\perps\\{INSTID}\\cvd_1m.jsonl
+- Vault\\derived\\vwap\\okx\\perps\\{INSTID}\\vwap_1m.jsonl
 
 OUTPUT:
-- C:\Users\M.R Bear\Documents\RaveQuant\Analysis\confluence_signals.jsonl
+- C:\\Users\\M.R Bear\\Documents\\RaveQuant\\Analysis\\confluence_signals.jsonl
 """
 
+import os
 import json
 import logging
 from pathlib import Path
@@ -30,8 +31,8 @@ from typing import List, Dict, Optional
 from collections import defaultdict
 
 # Paths
-VAULT_BASE = Path(r"C:\Users\M.R Bear\Documents\RaveQuant\Rave_Quant_Vault")
-OUTPUT_DIR = Path(r"C:\Users\M.R Bear\Documents\RaveQuant\Analysis")
+VAULT_BASE = Path(os.environ.get("RAVE_VAULT_BASE", Path(__file__).resolve().parent.parent / "Rave_Quant_Vault"))
+OUTPUT_DIR = Path(os.environ.get("RAVEQUANT_BASE", Path(__file__).resolve().parent.parent)) / "Analysis"
 
 # Confluence thresholds
 PRICE_TOLERANCE_PCT = Decimal('0.5')  # 0.5% = tight confluence

--- a/Analysis/signal_dashboard.py
+++ b/Analysis/signal_dashboard.py
@@ -15,6 +15,7 @@ Quick health check for trading readiness.
 OUTPUT: Console display (no file output)
 """
 
+import os
 import json
 import logging
 from pathlib import Path
@@ -23,7 +24,7 @@ from datetime import datetime, timedelta, timezone
 from typing import Optional, Dict
 
 # Paths
-VAULT_BASE = Path(r"C:\Users\M.R Bear\Documents\RaveQuant\Rave_Quant_Vault")
+VAULT_BASE = Path(os.environ.get("RAVE_VAULT_BASE", Path(__file__).resolve().parent.parent / "Rave_Quant_Vault"))
 
 # Freshness thresholds
 MAX_AGE_MINUTES = 15  # Data older than 15min = stale

--- a/CVD/run_cvd_from_jsonl.py
+++ b/CVD/run_cvd_from_jsonl.py
@@ -23,6 +23,7 @@ OUTPUT: Vault\\derived\\cvd\\okx\\{SYMBOL}\\1m\\{DATE}.jsonl
 STATE: Vault\\state\\cvd\\okx\\{SYMBOL}.state.json
 """
 
+import os
 import json
 import logging
 from pathlib import Path
@@ -40,7 +41,7 @@ logging.basicConfig(
 logger = logging.getLogger('CVD_Calculator')
 
 # Paths
-VAULT_BASE = Path(r"C:\Users\M.R Bear\Documents\RaveQuant\Rave_Quant_Vault")
+VAULT_BASE = Path(os.environ.get("RAVE_VAULT_BASE", Path(__file__).resolve().parent.parent / "Rave_Quant_Vault"))
 
 
 @dataclass

--- a/Liquidity_Buckets/l2_bucketizer.py
+++ b/Liquidity_Buckets/l2_bucketizer.py
@@ -15,6 +15,7 @@ OUTPUT: Vault\derived\liquidity_buckets\okx\perps\{INSTID}\{DATE}.jsonl
 STATE: Vault\state\liquidity_buckets\okx\perps\{INSTID}.state.json
 """
 
+import os
 import json
 import logging
 from pathlib import Path
@@ -28,7 +29,7 @@ import argparse
 getcontext().prec = 50
 
 # Paths
-VAULT_BASE = Path(r"C:\Users\M.R Bear\Documents\RaveQuant\Rave_Quant_Vault")
+VAULT_BASE = Path(os.environ.get("RAVE_VAULT_BASE", Path(__file__).resolve().parent.parent / "Rave_Quant_Vault"))
 
 # Instruments
 INSTRUMENTS = ["BTC-USDT-SWAP", "ETH-USDT-SWAP"]

--- a/Trades_Bot/trades_exporter.py
+++ b/Trades_Bot/trades_exporter.py
@@ -5,10 +5,11 @@ Captures raw perpetual swap trades from OKX WebSocket.
 Writes append-only JSONL with full contract metadata.
 
 INSTRUMENTS: BTC-USDT-SWAP, ETH-USDT-SWAP ONLY
-OUTPUT: Vault\raw\okx\trades_perps\{INSTID}\{DATE}.jsonl
+OUTPUT: Vault\\raw\\okx\\trades_perps\\{INSTID}\\{DATE}.jsonl
 """
 
 import asyncio
+import os
 import json
 import logging
 import requests
@@ -19,7 +20,7 @@ import websockets
 
 # Configuration
 INSTRUMENTS = ["BTC-USDT-SWAP", "ETH-USDT-SWAP"]
-VAULT_BASE = Path(r"C:\Users\M.R Bear\Documents\RaveQuant\Rave_Quant_Vault")
+VAULT_BASE = Path(os.environ.get("RAVE_VAULT_BASE", Path(__file__).resolve().parent.parent / "Rave_Quant_Vault"))
 WS_URL = "wss://ws.okx.com:8443/ws/v5/public"
 REST_BASE = "https://www.okx.com"
 

--- a/Untouch_Wick/find_signals.py
+++ b/Untouch_Wick/find_signals.py
@@ -5,6 +5,7 @@ Find small wicks 20-40 min old, still untouched, surrounded by touched wicks.
 These are your highest conviction setups - the "on the money" entries.
 """
 
+import os
 import json
 import logging
 from pathlib import Path
@@ -13,7 +14,7 @@ from typing import List, Dict
 import argparse
 
 # Paths
-VAULT_BASE = Path(r"C:\Users\M.R Bear\Documents\RaveQuant\Rave_Quant_Vault")
+VAULT_BASE = Path(os.environ.get("RAVE_VAULT_BASE", Path(__file__).resolve().parent.parent / "Rave_Quant_Vault"))
 
 # Logging
 logging.basicConfig(

--- a/Untouch_Wick/untouch_wick.py
+++ b/Untouch_Wick/untouch_wick.py
@@ -9,6 +9,7 @@ Fixed Issues:
 SCOPE: BTC-USDT-SWAP, ETH-USDT-SWAP (PERPS ONLY)
 """
 
+import os
 import json
 import logging
 import argparse
@@ -21,7 +22,7 @@ from candle_builder import Trade, Candle, build_all_timeframes
 from wick_detector import WickEvent, detect_wicks
 
 # Paths
-VAULT_BASE = Path(r"C:\Users\M.R Bear\Documents\RaveQuant\Rave_Quant_Vault")
+VAULT_BASE = Path(os.environ.get("RAVE_VAULT_BASE", Path(__file__).resolve().parent.parent / "Rave_Quant_Vault"))
 
 # Configuration
 INSTRUMENTS = ["BTC-USDT-SWAP", "ETH-USDT-SWAP"]

--- a/VWAP/vwap_calculator.py
+++ b/VWAP/vwap_calculator.py
@@ -17,6 +17,7 @@ OUTPUT: Vault\derived\vwap\okx\perps\{INSTID}\vwap_1m.jsonl
 STATE: Vault\state\vwap\okx\perps\{INSTID}.state.json
 """
 
+import os
 import json
 import logging
 from pathlib import Path
@@ -31,7 +32,7 @@ import argparse
 getcontext().prec = 50
 
 # Configuration
-VAULT_BASE = Path(r"C:\Users\M.R Bear\Documents\RaveQuant\Rave_Quant_Vault")
+VAULT_BASE = Path(os.environ.get("RAVE_VAULT_BASE", Path(__file__).resolve().parent.parent / "Rave_Quant_Vault"))
 
 # Window sizes (minutes)
 WINDOW_1H = 60

--- a/Volume_Analyzer/volume_analyzer.py
+++ b/Volume_Analyzer/volume_analyzer.py
@@ -9,11 +9,12 @@ From .txt insights:
 - Absorption detection: Price flat + volume surge = wall defense
 - Divergence detection: Price vs volume direction mismatch = exhaustion
 
-INPUT: Vault\raw\okx\trades_perps\{INSTID}\{DATE}.jsonl
-OUTPUT: Vault\derived\volume\okx\perps\{INSTID}\volume_1m.jsonl
-STATE: Vault\state\volume\okx\perps\{INSTID}.state.json
+INPUT: Vault\\raw\\okx\\trades_perps\\{INSTID}\\{DATE}.jsonl
+OUTPUT: Vault\\derived\\volume\\okx\\perps\\{INSTID}\\volume_1m.jsonl
+STATE: Vault\\state\\volume\\okx\\perps\\{INSTID}.state.json
 """
 
+import os
 import json
 import logging
 from pathlib import Path
@@ -28,7 +29,7 @@ import argparse
 getcontext().prec = 50
 
 # Paths
-VAULT_BASE = Path(r"C:\Users\M.R Bear\Documents\RaveQuant\Rave_Quant_Vault")
+VAULT_BASE = Path(os.environ.get("RAVE_VAULT_BASE", Path(__file__).resolve().parent.parent / "Rave_Quant_Vault"))
 
 # Thresholds
 WHALE_THRESHOLD_USD = Decimal('100000')  # $100k+ = whale

--- a/coinayalze_bot/coinalyze_bot.py
+++ b/coinayalze_bot/coinalyze_bot.py
@@ -48,7 +48,7 @@ class CoinalyzeBot:
     INTERVAL_1MIN = "1min"
     INTERVAL_5MIN = "5min"
     
-    def __init__(self, api_key: str, vault_base_path: str = r"C:\Users\M.R Bear\Documents\RaveQuant\Rave_Quant_Vault"):
+    def __init__(self, api_key: str, vault_base_path: str = os.environ.get("RAVE_VAULT_BASE", str(Path(__file__).resolve().parent.parent / "Rave_Quant_Vault"))):
         """
         Initialize Coinalyze bot.
         

--- a/repair_plan.md
+++ b/repair_plan.md
@@ -1,0 +1,6 @@
+# Repair Plan
+
+1. Fix `SyntaxError: (unicode error) 'unicodeescape' codec can't decode bytes` in `Analysis/confluence_analyzer.py` due to using single backslashes `\` in docstring `\d` and `\w`. Escape backslashes as `\\`.
+2. Fix `SyntaxWarning: invalid escape sequence '\o'` in `Trades_Bot/trades_exporter.py` docstring.
+3. Fix `SyntaxWarning: invalid escape sequence '\o'` in `Volume_Analyzer/volume_analyzer.py` docstring.
+4. Replace hardcoded `C:\Users\M.R Bear\Documents\RaveQuant` paths with dynamic resolution using `os.environ.get('RAVEQUANT_BASE')` or `Path(__file__).resolve().parent.parent` to fix hardcoded absolute paths on Windows to be cross-platform, according to the memory "The codebase avoids hardcoded absolute paths (like Windows paths), strictly utilizing environment variables and dynamic relative paths for portability."

--- a/run_all.py
+++ b/run_all.py
@@ -1,3 +1,4 @@
+import os
 """
 MASTER RUNNER - Start All RaveQuant Systems
 ============================================
@@ -19,7 +20,7 @@ from typing import List, Dict
 import json
 
 # Base paths
-RAVEQUANT_BASE = Path(r"C:\Users\M.R Bear\Documents\RaveQuant")
+RAVEQUANT_BASE = Path(os.environ.get("RAVEQUANT_BASE", Path(__file__).resolve().parent))
 
 # Component paths
 COMPONENTS = {


### PR DESCRIPTION
Refactor codebase to fix Windows paths and python string escape sequences

- Fixed `SyntaxError` and `SyntaxWarning` issues caused by unescaped backslashes in docstrings for `Analysis/confluence_analyzer.py`, `Trades_Bot/trades_exporter.py`, and `Volume_Analyzer/volume_analyzer.py`.
- Replaced hardcoded user-specific absolute Windows paths (`C:\Users\M.R Bear\Documents\RaveQuant`) with cross-platform dynamic relative path resolution using `os.environ` and `pathlib.Path(__file__)` across core analysis files, bot files, and `run_all.py`.
- Included a `repair_plan.md` documenting these findings.

---
*PR created automatically by Jules for task [119885946098195875](https://jules.google.com/task/119885946098195875) started by @MattRbear*

## Summary by Sourcery

Replace hardcoded Windows-specific paths with configurable, cross-platform path resolution and document the associated repair work.

Enhancements:
- Use environment variables and script-relative paths instead of hardcoded absolute Windows vault and project directories across analyzers, bots, and utilities.
- Default bot configuration to derive the vault base path from environment or project layout rather than a user-specific Windows path.

Documentation:
- Add a repair_plan.md documenting path and string-escape issues and the planned fixes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor limited to path resolution and docstring escaping; main risk is misconfigured `RAVE_VAULT_BASE`/`RAVEQUANT_BASE` causing scripts to read/write from unexpected locations.
> 
> **Overview**
> **Improves portability across the tooling suite** by replacing user-specific `C:\...` and other hardcoded path constants with environment-variable overrides (e.g., `RAVE_VAULT_BASE`, `RAVEQUANT_BASE`) and `Path(__file__)`-based defaults in the analyzer, dashboard, calculators, and bots.
> 
> **Fixes Python escape-sequence issues** in several docstrings by escaping backslashes (preventing `unicodeescape` errors / `invalid escape sequence` warnings), and adds `repair_plan.md` documenting the path/escape repairs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0fb337be3eb111dfaf7eb6176cc47ff4d1124dc9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->