### PR TITLE
Fix SyntaxWarnings and SyntaxErrors resulting from invalid escape sequences

### DIFF
--- a/Analysis/confluence_analyzer.py
+++ b/Analysis/confluence_analyzer.py
@@ -11,14 +11,14 @@ Reads all data sources and identifies max conviction setups where:
 Outputs ranked trade signals with conviction scores.
 
 INPUT:
-- Vault\derived\wicks\okx\perps\{INSTID}\wicks_events.jsonl
-- Vault\derived\volume\okx\perps\{INSTID}\volume_1m.jsonl
-- Vault\derived\liquidity_buckets\okx\perps\{INSTID}\{DATE}.jsonl
-- Vault\derived\cvd\okx\perps\{INSTID}\cvd_1m.jsonl
-- Vault\derived\vwap\okx\perps\{INSTID}\vwap_1m.jsonl
+- Vault\\derived\\wicks\\okx\\perps\\{INSTID}\\wicks_events.jsonl
+- Vault\\derived\\volume\\okx\\perps\\{INSTID}\\volume_1m.jsonl
+- Vault\\derived\\liquidity_buckets\\okx\\perps\\{INSTID}\\{DATE}.jsonl
+- Vault\\derived\\cvd\\okx\\perps\\{INSTID}\\cvd_1m.jsonl
+- Vault\\derived\\vwap\\okx\\perps\\{INSTID}\\vwap_1m.jsonl
 
 OUTPUT:
-- C:\Users\M.R Bear\Documents\RaveQuant\Analysis\confluence_signals.jsonl
+- C:\\Users\\M.R Bear\\Documents\\RaveQuant\\Analysis\\confluence_signals.jsonl
 """
 
 import json

--- a/Trades_Bot/trades_exporter.py
+++ b/Trades_Bot/trades_exporter.py
@@ -5,7 +5,7 @@ Captures raw perpetual swap trades from OKX WebSocket.
 Writes append-only JSONL with full contract metadata.
 
 INSTRUMENTS: BTC-USDT-SWAP, ETH-USDT-SWAP ONLY
-OUTPUT: Vault\raw\okx\trades_perps\{INSTID}\{DATE}.jsonl
+OUTPUT: Vault\\raw\\okx\\trades_perps\\{INSTID}\\{DATE}.jsonl
 """
 
 import asyncio

--- a/Volume_Analyzer/volume_analyzer.py
+++ b/Volume_Analyzer/volume_analyzer.py
@@ -9,9 +9,9 @@ From .txt insights:
 - Absorption detection: Price flat + volume surge = wall defense
 - Divergence detection: Price vs volume direction mismatch = exhaustion
 
-INPUT: Vault\raw\okx\trades_perps\{INSTID}\{DATE}.jsonl
-OUTPUT: Vault\derived\volume\okx\perps\{INSTID}\volume_1m.jsonl
-STATE: Vault\state\volume\okx\perps\{INSTID}.state.json
+INPUT: Vault\\raw\\okx\\trades_perps\\{INSTID}\\{DATE}.jsonl
+OUTPUT: Vault\\derived\\volume\\okx\\perps\\{INSTID}\\volume_1m.jsonl
+STATE: Vault\\state\\volume\\okx\\perps\\{INSTID}.state.json
 """
 
 import json

--- a/repair_plan.md
+++ b/repair_plan.md
@@ -1,0 +1,23 @@
+# Codebase Repair Plan
+
+## Issues Found
+A repository-wide check for syntax errors and warnings using `python -m py_compile` and `flake8` revealed the following issues related to invalid unicode escape sequences and string literals:
+1. `Analysis/confluence_analyzer.py`: `SyntaxError: (unicode error) 'unicodeescape' codec can't decode bytes` due to `\U` in a raw path string that was not properly escaped.
+2. `Volume_Analyzer/volume_analyzer.py`: `SyntaxWarning: invalid escape sequence '\o'` in a docstring containing Windows file paths.
+3. `Trades_Bot/trades_exporter.py`: `SyntaxWarning: invalid escape sequence '\o'` in a docstring containing Windows file paths.
+
+These issues happen because unescaped backslashes (`\`) followed by certain characters (like `\o` in `\okx` or `\U` in `\Users`) are interpreted as escape sequences by the Python parser, resulting in warnings or syntax errors.
+
+## Adjustments and Changes Made
+1. **`Analysis/confluence_analyzer.py`**:
+   - Replaced single backslashes (`\`) with double backslashes (`\\`) in the `INPUT` and `OUTPUT` path strings within the docstring (e.g., `Vault\derived\...` to `Vault\\derived\...` and `C:\Users\...` to `C:\\Users\...`).
+
+2. **`Volume_Analyzer/volume_analyzer.py`**:
+   - Replaced single backslashes (`\`) with double backslashes (`\\`) in the `INPUT`, `OUTPUT`, and `STATE` path strings within the docstring.
+
+3. **`Trades_Bot/trades_exporter.py`**:
+   - Replaced single backslashes (`\`) with double backslashes (`\\`) in the `OUTPUT` path string within the docstring.
+
+## Verification
+- Ran `flake8 . --select=E9,F63,F7,F82` which confirmed no syntax errors remain.
+- Ran `find . -name "*.py" -exec python -m py_compile {} +` which confirmed no `SyntaxWarning` or `SyntaxError` instances remain across the entire codebase.


### PR DESCRIPTION
A codebase-wide check using `flake8` and `python -m py_compile` revealed several syntax warnings and errors due to incorrectly formed file path strings in docstrings. Replaced single backslashes `\` with double backslashes `\\` for `INPUT`, `OUTPUT`, and `STATE` paths in multiple modules. Created a `repair_plan.md` containing all adjustments. Verified tests successfully and completed all required documentation.

---
*PR created automatically by Jules for task [5310470790269625284](https://jules.google.com/task/5310470790269625284) started by @MattRbear*

## Summary by Sourcery

Resolve syntax errors and warnings caused by invalid escape sequences in Python modules and document the applied fixes.

Bug Fixes:
- Correct invalid backslash escape sequences in docstring file path examples across analysis, volume analyzer, and trades exporter modules to eliminate SyntaxError and SyntaxWarning issues.

Documentation:
- Add a repair_plan.md document describing detected syntax issues, the specific modules adjusted, and the verification steps performed.