### PR TITLE
🧹 fix: remove unused Dict import in run_all.py

### DIFF
--- a/run_all.py
+++ b/run_all.py
@@ -15,7 +15,7 @@ import subprocess
 import sys
 import time
 from pathlib import Path
-from typing import List, Dict
+from typing import List
 import json
 
 # Base paths


### PR DESCRIPTION
🎯 **What:** Removed the unused `Dict` import from `typing` in `run_all.py`.
💡 **Why:** This improves the code readability and maintainability by removing unnecessary imports, reducing visual clutter and strictly adhering to linting rules.
✅ **Verification:** Ran `python -m py_compile run_all.py` to ensure syntax remains valid and no regressions were introduced.
✨ **Result:** A cleaner import section without affecting any functionalities.

---
*PR created automatically by Jules for task [13859939035327146205](https://jules.google.com/task/13859939035327146205) started by @MattRbear*

## Summary by Sourcery

Enhancements:
- Simplify run_all.py imports by removing an unused Dict import from typing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: import-only cleanup with no runtime behavior changes.
> 
> **Overview**
> Removes the unused `Dict` import from `typing` in `run_all.py`, leaving only `List` to reduce lint/visual clutter with **no functional changes**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f57c9ecb443eaada29466ab033f5aa48a0ec7baf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->