### PR TITLE
🧪 Add tests for stable_hash in extract_nova_chat.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+__pycache__/
+*.py[cod]
+*$py.class
+*.log
+.env
+.pytest_cache/

--- a/tests/test_extract_nova_chat.py
+++ b/tests/test_extract_nova_chat.py
@@ -1,0 +1,47 @@
+from extract_nova_chat import stable_hash
+
+def test_stable_hash():
+    """Test that stable_hash generates correct deterministic hashes."""
+
+    # Deterministic output for known input
+    hash1 = stable_hash("hello world")
+    assert hash1 == stable_hash("hello world")
+
+    # Length is exactly 16 chars
+    assert len(hash1) == 16
+
+    # Different inputs yield different hashes
+    assert hash1 != stable_hash("Hello world")
+
+    # Empty string
+    empty_hash = stable_hash("")
+    assert len(empty_hash) == 16
+    assert empty_hash == stable_hash("")
+
+def test_stable_hash_unicode():
+    """Test that stable_hash handles unicode characters correctly."""
+
+    # Unicode characters
+    hash_unicode = stable_hash("こんにちは世界")
+    assert len(hash_unicode) == 16
+    assert hash_unicode == stable_hash("こんにちは世界")
+
+    # Emoji
+    hash_emoji = stable_hash("hello 🌍")
+    assert len(hash_emoji) == 16
+    assert hash_emoji == stable_hash("hello 🌍")
+
+    # Unicode and ASCII difference
+    assert stable_hash("cafe") != stable_hash("café")
+
+def test_stable_hash_invalid_surrogates():
+    """Test that stable_hash gracefully handles strings with invalid surrogates using errors='replace'."""
+
+    # Invalid surrogate pair which can cause errors during utf-8 encoding without errors='replace'
+    # Python 3 strings are unicode. We use a surrogate sequence.
+    invalid_string = "hello \ud800 world"
+
+    # Should not raise UnicodeEncodeError
+    hash_invalid = stable_hash(invalid_string)
+    assert len(hash_invalid) == 16
+    assert hash_invalid == stable_hash(invalid_string)


### PR DESCRIPTION
This commit introduces a new test file `tests/test_extract_nova_chat.py` to add coverage for the `stable_hash` utility function found in `extract_nova_chat.py`. It comprehensively tests various input types, including empty strings, unicode characters, emojis, and invalid surrogate strings to ensure the `errors='replace'` logic holds up deterministically. 

It also adds a standard `.gitignore` at the repository root to prevent artifacts like `__pycache__` and `.pytest_cache/` from polluting the codebase moving forward.

---
*PR created automatically by Jules for task [17043383816663745995](https://jules.google.com/task/17043383816663745995) started by @MattRbear*

## Summary by Sourcery

Add tests for the stable_hash helper and introduce a repository-level .gitignore.

Tests:
- Add unit tests covering stable_hash behavior for deterministic output, empty strings, unicode, emojis, and invalid surrogate sequences.

Chores:
- Add a root .gitignore to exclude common Python and test-related artifacts from version control.