### PR TITLE
🧹 Remove unused Dict import in VWAP calculator

### DIFF
--- a/VWAP/vwap_calculator.py
+++ b/VWAP/vwap_calculator.py
@@ -22,7 +22,7 @@ import logging
 from pathlib import Path
 from decimal import Decimal, getcontext
 from datetime import datetime, timedelta, timezone
-from typing import List, Dict, Optional
+from typing import List, Optional
 from dataclasses import dataclass
 from collections import deque
 import argparse


### PR DESCRIPTION
🎯 **What:** Removed the unused `Dict` import from `VWAP/vwap_calculator.py`.
💡 **Why:** Static analysis identified that `Dict` was imported from `typing` but never used within the file. Removing it improves code health, reduces clutter, and avoids linter warnings.
✅ **Verification:** Verified syntax using `python -m py_compile VWAP/vwap_calculator.py` and ran the test suite using `PYTHONPATH=. pytest` to ensure no functionality regressions were introduced.
✨ **Result:** A cleaner import statement (`from typing import List, Optional`) that accurately reflects the module's dependencies.

---
*PR created automatically by Jules for task [54279625633568579](https://jules.google.com/task/54279625633568579) started by @MattRbear*

## Summary by Sourcery

Enhancements:
- Remove unused Dict import from the VWAP calculator to reduce clutter and satisfy static analysis.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk cleanup that only removes an unused `typing.Dict` import and does not change runtime behavior.
> 
> **Overview**
> Removes the unused `Dict` import from `VWAP/vwap_calculator.py`, leaving only the `typing` imports that are actually referenced (`List`, `Optional`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af84c71210a44768bce934faa285a302e1534226. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->