### PR TITLE
🧹 [Code Health] Remove unused `floor_to_midnight_utc` function

### DIFF
--- a/VWAP/vwap_calculator.py
+++ b/VWAP/vwap_calculator.py
@@ -95,16 +95,6 @@ class VWAPState:
     last_session_date: Optional[str]  # YYYY-MM-DD for session tracking
 
 
-def floor_to_midnight_utc(ts: datetime) -> datetime:
-    """
-    Floor timestamp to midnight UTC (00:00:00).
-    
-    RESEARCH: "Standard institutional VWAP in crypto resets at 00:00 UTC.
-    This ensures global data parity and consistent support/resistance levels."
-    """
-    return ts.replace(hour=0, minute=0, second=0, microsecond=0)
-
-
 def floor_to_minute(ts: datetime) -> datetime:
     """Floor timestamp to nearest minute."""
     return ts.replace(second=0, microsecond=0)


### PR DESCRIPTION
🎯 **What:** Removed the unused `floor_to_midnight_utc` function from `VWAP/vwap_calculator.py`.
💡 **Why:** To improve code health and maintainability by removing dead code. Static analysis confirmed this function was safe to remove. The actual session reset logic correctly uses `trade_time.date().isoformat()` rather than this function.
✅ **Verification:** Verified syntax using `python -m py_compile` and linting with `flake8`. Ran tests using `pytest` to ensure no regressions (note: VWAP module currently lacks tests, but the global test suite runs).
✨ **Result:** Cleaner codebase with no unused functions in the VWAP module.

---
*PR created automatically by Jules for task [4078920858122558907](https://jules.google.com/task/4078920858122558907) started by @MattRbear*

## Summary by Sourcery

Remove an unused UTC midnight-flooring helper from the VWAP calculator to simplify the module and reduce dead code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk cleanup that removes dead code only; no functional VWAP/session logic changes are introduced.
> 
> **Overview**
> Removes the unused `floor_to_midnight_utc` helper from `VWAP/vwap_calculator.py` to eliminate dead code.
> 
> No call sites exist for this helper, so VWAP/session behavior remains unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7b72331cee94e7b633c364030e78194718c4420. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->