### PR TITLE
🧪 test: add unit tests for stable_hash in extract_nova_chat

### DIFF
--- a/tests/test_extract_nova_chat.py
+++ b/tests/test_extract_nova_chat.py
@@ -1,0 +1,41 @@
+import pytest
+from extract_nova_chat import stable_hash
+
+def test_stable_hash_consistency():
+    """Ensure the same input string produces the same hash consistently."""
+    text = "test_string_123"
+    assert stable_hash(text) == stable_hash(text)
+
+def test_stable_hash_length():
+    """Ensure the output hash is always 16 characters long."""
+    text1 = "short"
+    text2 = "this_is_a_much_longer_string_that_should_still_produce_16_chars"
+    assert len(stable_hash(text1)) == 16
+    assert len(stable_hash(text2)) == 16
+
+def test_stable_hash_empty_string():
+    """Ensure an empty string produces a valid 16-character hash."""
+    result = stable_hash("")
+    assert isinstance(result, str)
+    assert len(result) == 16
+
+def test_stable_hash_different_inputs():
+    """Ensure different inputs produce different hashes (up to 16 char prefix)."""
+    assert stable_hash("text1") != stable_hash("text2")
+
+def test_stable_hash_unicode():
+    """Ensure hashing works correctly with non-ASCII unicode characters."""
+    text = "hello world 😊🌍 testing"
+    assert len(stable_hash(text)) == 16
+    assert stable_hash(text) == stable_hash(text)
+    assert stable_hash("hello world 😊🌍 testing") != stable_hash("hello world 🌍😊 testing")
+
+def test_stable_hash_invalid_surrogates():
+    """Ensure invalid surrogate characters do not raise a UnicodeEncodeError."""
+    # This string contains a lone surrogate which is invalid in strictly encoded UTF-8
+    invalid_text = "test \ud800 string"
+    try:
+        result = stable_hash(invalid_text)
+        assert len(result) == 16
+    except UnicodeEncodeError:
+        pytest.fail("stable_hash raised UnicodeEncodeError with invalid surrogate characters.")


### PR DESCRIPTION
🎯 **What:** This PR addresses the missing unit test coverage for the `stable_hash` utility function in `extract_nova_chat.py`.
📊 **Coverage:** A test file `tests/test_extract_nova_chat.py` was introduced covering:
- Deterministic consistency of the hashing algorithm
- Correct constraint matching (always truncates to 16 characters)
- Safe handling of empty string inputs
- Avoidance of immediate collisions given different string inputs
- Correct handling of non-ASCII unicode string inputs
- Robust handling of invalid unicode surrogate characters (verifying it does not raise `UnicodeEncodeError`).
✨ **Result:** Test coverage for `extract_nova_chat.py` has improved, and the reliability of the `stable_hash` utility function is now enforced mechanically via the automated `pytest` suite.

---
*PR created automatically by Jules for task [9896867097410843221](https://jules.google.com/task/9896867097410843221) started by @MattRbear*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new `pytest` test module only, with no production code changes. Main risk is potential CI/test-environment mismatch if `pytest` isn’t already part of the project’s test setup.
> 
> **Overview**
> Adds a new `pytest` suite (`tests/test_extract_nova_chat.py`) covering `extract_nova_chat.stable_hash` behavior.
> 
> Tests assert deterministic output, fixed 16-character truncation, handling of empty strings, basic non-collision for different inputs, correct unicode hashing, and resilience to invalid surrogate characters (no `UnicodeEncodeError`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f133753cae6a1e5d2bc4b004451c07a3de3958e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Summary by Sourcery

Add unit test coverage for the stable_hash utility in extract_nova_chat to ensure deterministic, robust hashing behavior.

Tests:
- Introduce tests validating hash determinism, fixed 16-character length, and behavior for empty strings.
- Add tests to verify distinct hashes for different inputs, including non-ASCII Unicode strings and reordered emoji.
- Add regression test ensuring stable_hash safely handles invalid Unicode surrogate characters without raising UnicodeEncodeError.