### PR TITLE
🧹 [Code Health] Remove unused Dict import in run_all.py

### DIFF
--- a/run_all.py
+++ b/run_all.py
@@ -15,7 +15,7 @@ import subprocess
 import sys
 import time
 from pathlib import Path
-from typing import List, Dict
+from typing import List
 import json
 
 # Base paths


### PR DESCRIPTION
🎯 **What:** Removed the unused `Dict` import from the `typing` module on line 18 in `run_all.py`.
💡 **Why:** `Dict` was imported but never utilized within the script, as it relies on standard `dict` literal syntax `{}` or implicit typing. Removing it improves code health, readability, and cleans up the namespace without altering any behavior.
✅ **Verification:** Verified via `python -m py_compile run_all.py` and running `python run_all.py --check-only` successfully. Executed the `pytest` test suite (0 tests found, completed without errors). `__pycache__` artifacts were meticulously omitted from the commit.
✨ **Result:** A cleaner `run_all.py` file with unnecessary dependencies successfully removed.

---
*PR created automatically by Jules for task [183978610708444863](https://jules.google.com/task/183978610708444863) started by @MattRbear*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit bed15bfdf19e759b3a42de7c501735559ba056c1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Summary by Sourcery

Enhancements:
- Remove unused Dict import from run_all.py to simplify dependencies and improve code cleanliness.