### PR TITLE
🧹 Remove unused datetime imports in CVD calculator

### DIFF
--- a/CVD/run_cvd_from_jsonl.py
+++ b/CVD/run_cvd_from_jsonl.py
@@ -27,7 +27,7 @@ import json
 import logging
 from pathlib import Path
 from decimal import Decimal
-from datetime import datetime, timedelta, timezone
+from datetime import datetime
 from typing import Optional, Dict, List
 from dataclasses import dataclass
 import argparse


### PR DESCRIPTION
🎯 **What:** Removed unused imports (`timedelta`, `timezone`) from `datetime` in `CVD/run_cvd_from_jsonl.py`.
💡 **Why:** Improves code maintainability and readability by eliminating dead code, resolving static analysis warnings.
✅ **Verification:** Verified that `datetime` is still used and functioning. Checked syntax and lint via `flake8`, executed script with `-h` to parse safely, ran `pytest` suite for regressions.
✨ **Result:** Cleaner import statements with zero functional changes or side effects.

---
*PR created automatically by Jules for task [4172247216713917918](https://jules.google.com/task/4172247216713917918) started by @MattRbear*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk cleanup that only removes unused `datetime` imports and does not change runtime behavior.
> 
> **Overview**
> Removes unused `timedelta` and `timezone` imports from `CVD/run_cvd_from_jsonl.py`, leaving only `datetime` to reduce lint/static-analysis noise with no functional changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99877f1ae8e56d843c17059b4ec7c5545a33e6fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Summary by Sourcery

Enhancements:
- Clean up import statements in CVD/run_cvd_from_jsonl.py by removing unused timedelta and timezone imports without changing runtime behavior.