### PR TITLE
🧪 test(extract_nova_chat): add missing tests for detect_file_format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.py[cod]
+*.log
+.env
+.pytest_cache/

--- a/tests/test_extract_nova_chat.py
+++ b/tests/test_extract_nova_chat.py
@@ -1,0 +1,29 @@
+import pytest
+from pathlib import Path
+from extract_nova_chat import detect_file_format
+
+def test_detect_file_format_json():
+    assert detect_file_format(Path("file.json")) == "json"
+    assert detect_file_format(Path("path/to/file.json")) == "json"
+    assert detect_file_format(Path("file.JSON")) == "json"
+
+def test_detect_file_format_jsonl():
+    assert detect_file_format(Path("file.jsonl")) == "jsonl"
+    assert detect_file_format(Path("file.JSONL")) == "jsonl"
+
+def test_detect_file_format_plaintext():
+    assert detect_file_format(Path("file.txt")) == "plaintext"
+    assert detect_file_format(Path("file.md")) == "plaintext"
+    assert detect_file_format(Path("file.TXT")) == "plaintext"
+    assert detect_file_format(Path("file.Md")) == "plaintext"
+
+def test_detect_file_format_html():
+    assert detect_file_format(Path("file.html")) == "html"
+    assert detect_file_format(Path("file.htm")) == "html"
+    assert detect_file_format(Path("file.HTML")) == "html"
+
+def test_detect_file_format_unknown():
+    assert detect_file_format(Path("file.pdf")) == "unknown"
+    assert detect_file_format(Path("file.csv")) == "unknown"
+    assert detect_file_format(Path("file.jpg")) == "unknown"
+    assert detect_file_format(Path("file_without_extension")) == "unknown"


### PR DESCRIPTION
🎯 **What:** Added tests for the `detect_file_format` function in `extract_nova_chat.py` which was completely missing tests.
📊 **Coverage:** Tested for `.json`, `.jsonl`, plaintext (`.txt`, `.md`), HTML (`.html`, `.htm`), and unknown formats. Verified handling of case-insensitivity and files without extensions.
✨ **Result:** Improved reliability and test coverage for the chat extraction logic. Tests are now separated into a dedicated `tests/test_extract_nova_chat.py` file using the `pytest` framework, successfully creating the test foundation. Also added a `.gitignore` to avoid `.pyc` clutter.

---
*PR created automatically by Jules for task [322352547117787791](https://jules.google.com/task/322352547117787791) started by @MattRbear*

## Summary by Sourcery

Add missing tests for detect_file_format and ignore Python bytecode artifacts.

Build:
- Add a .gitignore entry to exclude Python bytecode files from version control.

Tests:
- Add pytest-based coverage for detect_file_format handling of json, jsonl, plaintext, html, and unknown formats, including case-insensitive extensions and paths.
- Verify detect_file_format behavior for files without extensions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds new pytest coverage and a `.gitignore` without changing runtime behavior. Only potential risk is minor CI/test-runner setup expectations if pytest wasn’t previously used.
> 
> **Overview**
> Adds a new pytest suite (`tests/test_extract_nova_chat.py`) to validate `detect_file_format` across `.json`, `.jsonl`, plaintext (`.txt`/`.md`), HTML (`.html`/`.htm`), and unknown extensions, including case-insensitivity and no-extension paths.
> 
> Introduces a `.gitignore` to exclude common Python build/runtime artifacts (e.g., `__pycache__`, `*.pyc`, `.pytest_cache`, `.env`, logs).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 133d4b6ddcd36c39efe73007ad9debd439d0ccb2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->