### PR TITLE
🧹 Refactor size_usd property out of Trade dataclass in run_cvd_from_jsonl.py

### DIFF
--- a/CVD/run_cvd_from_jsonl.py
+++ b/CVD/run_cvd_from_jsonl.py
@@ -69,11 +69,6 @@ class Trade:
     side: str  # 'buy' or 'sell' (AGGRESSOR side)
     
     @property
-    def size_usd(self) -> Decimal:
-        """Calculate size in USD (notional volume)."""
-        return Decimal(self.price) * Decimal(self.size)
-    
-    @property
     def timestamp(self) -> datetime:
         """Parse timestamp to datetime."""
         return datetime.fromisoformat(self.timestamp_utc.replace('Z', '+00:00'))
@@ -187,13 +182,15 @@ def calculate_cvd_updates(trades: List[Trade], start_cvd: Decimal) -> Dict[datet
             minute_buy_volume = Decimal('0')
             minute_sell_volume = Decimal('0')
         
+        trade_size_usd = Decimal(trade.price) * Decimal(trade.size)
+
         # Update CVD (cumulative)
         if trade.side == 'buy':
-            cvd += trade.size_usd
-            minute_buy_volume += trade.size_usd
+            cvd += trade_size_usd
+            minute_buy_volume += trade_size_usd
         elif trade.side == 'sell':
-            cvd -= trade.size_usd
-            minute_sell_volume += trade.size_usd
+            cvd -= trade_size_usd
+            minute_sell_volume += trade_size_usd
         else:
             logger.warning(f"Unknown side: {trade.side} for trade {trade.trade_id}")
             continue


### PR DESCRIPTION
🎯 **What:** Removed the `@property def size_usd` from the `Trade` dataclass in `CVD/run_cvd_from_jsonl.py` and inlined its calculation into the `calculate_cvd_updates` function.
💡 **Why:** Static analysis flagged `size_usd` as dead code. While it was actually being used, calculating it dynamically inside the processing loop (by inlining `trade_size_usd = Decimal(trade.price) * Decimal(trade.size)`) avoids redundant string-to-Decimal conversions (which were happening twice per trade in the original loop) and improves performance in high-frequency data processing, without altering the logic.
✅ **Verification:** Ran syntax checks (`py_compile`) and the test suite (`pytest`) to confirm no regressions. Requested code review, which confirmed the refactoring is functionally safe. Verified that no `__pycache__` artifacts are left in the repository.
✨ **Result:** The `Trade` dataclass is now cleaner, and the continuous processing loop performs string-to-Decimal conversions more efficiently.

---
*PR created automatically by Jules for task [9153719281879657576](https://jules.google.com/task/9153719281879657576) started by @MattRbear*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor limited to CVD notional volume computation; main risk is unintended Decimal conversion/precision/performance changes in the per-trade loop.
> 
> **Overview**
> **Refactors CVD trade notional computation** by removing the `Trade.size_usd` property and inlining `Decimal(trade.price) * Decimal(trade.size)` inside `calculate_cvd_updates`.
> 
> This updates the CVD and per-minute buy/sell volume calculations to reuse a single `trade_size_usd` value per trade (avoiding repeated string-to-`Decimal` conversions) without changing the surrounding aggregation logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af14f3d62b4e798bd4abb4f96d482b84803ca062. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Summary by Sourcery

Enhancements:
- Remove the size_usd property from the Trade dataclass and compute trade_size_usd directly within the calculate_cvd_updates loop to avoid redundant Decimal conversions.