### PR TITLE
🧹 Code Health: Remove unused imports in VWAP/vwap_calculator.py

### DIFF
--- a/VWAP/vwap_calculator.py
+++ b/VWAP/vwap_calculator.py
@@ -21,8 +21,8 @@ import json
 import logging
 from pathlib import Path
 from decimal import Decimal, getcontext
-from datetime import datetime, timedelta, timezone
-from typing import List, Dict, Optional
+from datetime import datetime, timedelta
+from typing import List, Optional
 from dataclasses import dataclass
 from collections import deque
 import argparse


### PR DESCRIPTION
🎯 **What:** Removed unused `timezone` and `typing.Dict` imports in `VWAP/vwap_calculator.py`.
💡 **Why:** To improve code health by cleaning up unused imports, enhancing maintainability and readability.
✅ **Verification:** Ran `flake8` to confirm no unused imports or syntax errors remained. Ran `pytest` to ensure no tests broke. Checked with `python -m py_compile` to ensure syntax correctness.
✨ **Result:** A cleaner file without unnecessary imports, resolving linting warnings.

---
*PR created automatically by Jules for task [15749263736914653112](https://jules.google.com/task/15749263736914653112) started by @MattRbear*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 6f0e55afc6987f40214df7e585ad200a6e26d84d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Summary by Sourcery

Enhancements:
- Remove unused imports from VWAP/vwap_calculator.py to simplify the module and improve readability.