### PR TITLE
🧪 Add Unit Tests for detect_file_format in extract_nova_chat.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.py[cod]
+.pytest_cache/

--- a/tests/test_extract_nova_chat.py
+++ b/tests/test_extract_nova_chat.py
@@ -1,0 +1,33 @@
+import pytest
+from pathlib import Path
+import sys
+import os
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from extract_nova_chat import detect_file_format
+
+def test_detect_file_format_json():
+    assert detect_file_format(Path("data/test.json")) == "json"
+    assert detect_file_format(Path("TEST.JSON")) == "json"
+
+def test_detect_file_format_jsonl():
+    assert detect_file_format(Path("data/test.jsonl")) == "jsonl"
+    assert detect_file_format(Path("TEST.JSONL")) == "jsonl"
+
+def test_detect_file_format_plaintext():
+    assert detect_file_format(Path("doc.txt")) == "plaintext"
+    assert detect_file_format(Path("readme.md")) == "plaintext"
+    assert detect_file_format(Path("DOC.TXT")) == "plaintext"
+    assert detect_file_format(Path("README.MD")) == "plaintext"
+
+def test_detect_file_format_html():
+    assert detect_file_format(Path("page.html")) == "html"
+    assert detect_file_format(Path("index.htm")) == "html"
+    assert detect_file_format(Path("PAGE.HTML")) == "html"
+
+def test_detect_file_format_unknown():
+    assert detect_file_format(Path("data.csv")) == "unknown"
+    assert detect_file_format(Path("archive.zip")) == "unknown"
+    assert detect_file_format(Path("no_extension_file")) == "unknown"
+    assert detect_file_format(Path(".hidden")) == "unknown"


### PR DESCRIPTION
🎯 **What:** 
The testing gap addressed in `extract_nova_chat.py` function `detect_file_format`. The codebase was missing a comprehensive test suite to verify file extension handling and parsing.

📊 **Coverage:** 
- Valid target file extensions `.json`, `.jsonl`, `.txt`, `.md`, `.html`, `.htm`
- Case insensitivity functionality like `.JSON` and `.TXT` 
- Unknown Extensions like `.csv`, `.zip`
- Edge cases like hidden files `.hidden` and no extension names.

✨ **Result:** 
The improvement in test coverage guarantees safe handling across dataset formats as new parsing modules and logic may be integrated into `extract_nova_chat.py`. `.gitignore` was configured to support Pytest testing by ignoring `__pycache__` and cache directories.

---
*PR created automatically by Jules for task [6165752135047662673](https://jules.google.com/task/6165752135047662673) started by @MattRbear*

## Summary by Sourcery

Add unit test coverage for file format detection in extract_nova_chat to verify correct classification of common extensions and unknown files.

Build:
- Update .gitignore to exclude Python cache artifacts to support running the pytest test suite cleanly.

Tests:
- Add tests for detect_file_format to cover JSON, JSONL, plaintext, HTML/HTM, unknown extensions, hidden files, and missing extensions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adds tests and a `.gitignore`, with no runtime logic changes. Main risk is potential CI/test discovery path issues due to manual `sys.path` manipulation in the test.
> 
> **Overview**
> Adds a new pytest suite (`tests/test_extract_nova_chat.py`) that validates `detect_file_format` across supported extensions (`.json`, `.jsonl`, `.txt`/`.md`, `.html`/`.htm`), case-insensitivity, and unknown/edge cases (no extension, hidden files).
> 
> Introduces a `.gitignore` to exclude Python bytecode caches and pytest cache directories from version control.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93772b6a9925c3265798fa376c04d5f579433a98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->