### PR TITLE
🧪 test: add test suite for extract_nova_chat.py utility functions

### DIFF
--- a/test_extract_nova_chat.py
+++ b/test_extract_nova_chat.py
@@ -1,0 +1,52 @@
+import pytest
+import hashlib
+from extract_nova_chat import stable_hash, strip_html
+
+def test_stable_hash():
+    # Deterministic output
+    text1 = "hello world"
+    assert stable_hash(text1) == stable_hash(text1)
+
+    # Different inputs yield different outputs
+    text2 = "hello world 2"
+    assert stable_hash(text1) != stable_hash(text2)
+
+    # Output length is exactly 16 chars
+    assert len(stable_hash(text1)) == 16
+    assert len(stable_hash("")) == 16
+
+    # Unicode behavior
+    text_unicode = "hello 🤖"
+    # Verify it doesn't crash and returns the expected format
+    assert len(stable_hash(text_unicode)) == 16
+
+    # Check actual hash value to guarantee stability
+    # "hello world" encoded in utf-8 -> sha256 -> first 16 hex chars
+    expected_hash = hashlib.sha256("hello world".encode("utf-8")).hexdigest()[:16]
+    assert stable_hash("hello world") == expected_hash
+
+def test_strip_html():
+    # Simple tag removal
+    assert strip_html("<b>bold</b>") == "bold"
+    assert strip_html("<p>paragraph</p>") == "paragraph"
+
+    # HTML entity unescaping
+    assert strip_html("A &amp; B") == "A & B"
+    assert strip_html("A &lt; B") == "A < B"
+    assert strip_html("&quot;Quote&quot;") == '"Quote"'
+
+    # Collapsing multiple spaces
+    assert strip_html("  hello   world  ") == "hello world"
+    assert strip_html("hello\n\nworld") == "hello world"
+    assert strip_html("hello\tworld") == "hello world"
+
+    # Combination of tags, entities, and spaces
+    assert strip_html("<p>Hello &amp;   <b>World</b>!</p>") == "Hello & World !"
+
+    # Edge cases
+    assert strip_html("") == ""
+    assert strip_html("No HTML here") == "No HTML here"
+
+    # Nested and complex tags
+    assert strip_html("<div><p><span>deeply nested</span></p></div>") == "deeply nested"
+    assert strip_html("<a href='http://example.com?a=1&amp;b=2'>link</a>") == "link"


### PR DESCRIPTION
🎯 **What:** 
The issue highlighted a missing test suite for `extract_nova_chat.py`, specifically noting that it contains easily testable pure utility functions like `stable_hash` and `strip_html`.

📊 **Coverage:** 
- Added `test_stable_hash` testing deterministic generation, length validity, string variation handling, and unicode character support without runtime crashes.
- Added `test_strip_html` testing simple tag removal, HTML entity unescaping, robust whitespace collapsing, handling of complex nested tags, and behavior with empty strings.

✨ **Result:** 
The new test file introduces basic test coverage that will allow future developers to confidently refactor these core utility functions without fear of introducing hidden regressions. All test variations were executed via `pytest` successfully.

---
*PR created automatically by Jules for task [13101157554297191618](https://jules.google.com/task/13101157554297191618) started by @MattRbear*

## Summary by Sourcery

Add unit tests for core utility functions in extract_nova_chat.py to ensure their behavior is stable and well-defined.

Tests:
- Add test coverage for stable_hash, including determinism, output length, unicode handling, and a fixed expected hash value.
- Add test coverage for strip_html, including tag removal, HTML entity decoding, whitespace normalization, nested tags, and edge cases.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a standalone pytest file only, exercising existing pure utility functions without changing runtime code paths.
> 
> **Overview**
> Adds a new `pytest` suite for `extract_nova_chat.py` utility functions `stable_hash` and `strip_html`.
> 
> Tests verify `stable_hash` determinism, output length, unicode handling, and a fixed expected SHA-256 prefix, and validate `strip_html` tag removal, entity unescaping, whitespace normalization, and common edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2ad14709bfd2ad0996844b394154780f053f21f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->