### PR TITLE
🧹 Remove unused `List` import

### DIFF
--- a/extract_nova_chat.py
+++ b/extract_nova_chat.py
@@ -15,7 +15,7 @@ import hashlib
 import argparse
 import logging
 from pathlib import Path
-from typing import Dict, List, Optional, Any, Iterator, Set
+from typing import Dict, Optional, Any, Iterator, Set
 from collections import defaultdict
 from datetime import datetime
 import html


### PR DESCRIPTION
🎯 **What:** Removed unused `List` import from `typing` module in `extract_nova_chat.py`
💡 **Why:** Fixes a static analysis finding and improves code cleanliness by removing unused imports
✅ **Verification:** Ran `python extract_nova_chat.py --input a --output b --self-test` which passed successfully.
✨ **Result:** Improved maintainability by reducing unused code.

---
*PR created automatically by Jules for task [15359815283291591766](https://jules.google.com/task/15359815283291591766) started by @MattRbear*

## Summary by Sourcery

Enhancements:
- Simplify extract_nova_chat.py by removing an unused List import from the typing module.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk cleanup that only removes an unused import and should not affect runtime behavior.
> 
> **Overview**
> Removes the unused `List` import from `typing` in `extract_nova_chat.py` to satisfy static analysis and reduce dead code.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b1b2458f75535b50611e0ba0af0e31a2da9926e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->