### PR TITLE
🔒 Fix insecure hardcoded path for Coinalyze API key

### DIFF
--- a/coinayalze_bot/coinalyze_bot.py
+++ b/coinayalze_bot/coinalyze_bot.py
@@ -13,6 +13,7 @@ import logging
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Dict, List, Optional
+from dotenv import load_dotenv
 
 # Logging configuration
 logging.basicConfig(
@@ -371,21 +372,9 @@ class CoinalyzeBot:
 
 
 def load_api_key() -> Optional[str]:
-    """Load API key from environment or env file."""
-    # Try environment variable first
-    api_key = os.getenv('COINALYZE_API_KEY')
-    
-    if not api_key:
-        # Try loading from env file
-        env_file = Path(__file__).parent.parent.parent.parent / 'OneDrive' / 'Desktop' / 'all env.txt'
-        if env_file.exists():
-            with open(env_file, 'r') as f:
-                for line in f:
-                    if line.startswith('COINALYZE_API_KEY='):
-                        api_key = line.split('=')[1].strip()
-                        break
-    
-    return api_key
+    """Load API key from environment or local .env file."""
+    load_dotenv()
+    return os.getenv('COINALYZE_API_KEY')
 
 
 if __name__ == "__main__":

--- a/coinayalze_bot/requirements.txt
+++ b/coinayalze_bot/requirements.txt
@@ -1,3 +1,4 @@
 requests>=2.31.0
 python-dateutil
 pathlib
+python-dotenv


### PR DESCRIPTION
🎯 **What:** The `load_api_key` function in `coinalyze_bot.py` previously attempted to load the API key from a hardcoded fallback path (`C:\Users\...\OneDrive\Desktop\all env.txt`) if the environment variable was missing.

⚠️ **Risk:** This created a security vulnerability by encouraging users to store sensitive API keys in easily accessible, personal desktop files outside of the project's secure context. It also broke the Twelve-Factor App methodology for configuration management, hard-coupling the application to a specific user's file system layout.

🛡️ **Solution:** The hardcoded path has been removed entirely. The application now uses `python-dotenv` to attempt to load configuration variables from a standard local `.env` file into the environment before falling back to reading `os.getenv('COINALYZE_API_KEY')`. The `python-dotenv` dependency has been added to `requirements.txt`.

---
*PR created automatically by Jules for task [7959768514476781716](https://jules.google.com/task/7959768514476781716) started by @MattRbear*

## Summary by Sourcery

Use python-dotenv to load the Coinalyze API key from a local .env file instead of a user-specific hardcoded path.

New Features:
- Support loading configuration from a standard local .env file via python-dotenv.

Bug Fixes:
- Eliminate insecure hardcoded filesystem path fallback when loading the Coinalyze API key.

Build:
- Add python-dotenv as a runtime dependency in requirements.txt.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: configuration-loading change only, removing an insecure hardcoded local file fallback and adding a standard `.env` mechanism.
> 
> **Overview**
> Replaces the `load_api_key()` fallback that read `COINALYZE_API_KEY` from a hardcoded desktop file path with `python-dotenv` loading from a local `.env` before reading `os.getenv`.
> 
> Adds the `python-dotenv` dependency to `requirements.txt` to support the new configuration flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc05bec2b98eef7fca41ff82bade4a7a524d1dce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->