### PR TITLE
🧹 Remove unused Dict import in run_all.py

### DIFF
--- a/run_all.py
+++ b/run_all.py
@@ -15,7 +15,7 @@ import subprocess
 import sys
 import time
 from pathlib import Path
-from typing import List, Dict
+from typing import List
 import json
 
 # Base paths


### PR DESCRIPTION
🎯 **What:** Removed the unused `Dict` import from the `typing` module on line 18 in `run_all.py`.
💡 **Why:** It cleans up the code namespace and fixes a code health issue, improving maintainability and removing linter warnings.
✅ **Verification:** Verified via `flake8` to ensure the unused import warning is gone, and verified tests via `pytest`.
✨ **Result:** A slightly cleaner file with no unused imports.

---
*PR created automatically by Jules for task [9809250214664286502](https://jules.google.com/task/9809250214664286502) started by @MattRbear*

## Summary by Sourcery

Enhancements:
- Clean up run_all.py by removing an unused Dict import from typing to improve code health and maintainability.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: removes an unused `typing.Dict` import only, with no runtime behavior changes.
> 
> **Overview**
> Removes the unused `Dict` import from `run_all.py` by narrowing `from typing import List, Dict` to `from typing import List`, cleaning up the module and avoiding linter warnings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b627c10e7e48497e70a6f777be8a7ad158963b17. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->