### PR TITLE
🧹 refactor(vwap): encapsulate write_vwap_output arguments into VWAPMetrics dataclass

### DIFF
--- a/VWAP/vwap_calculator.py
+++ b/VWAP/vwap_calculator.py
@@ -95,6 +95,17 @@ class VWAPState:
     last_session_date: Optional[str]  # YYYY-MM-DD for session tracking
 
 
+@dataclass
+class VWAPMetrics:
+    """Encapsulates output metrics for VWAP."""
+    vwap_session: Optional[Decimal]
+    vwap_1h: Optional[Decimal]
+    vwap_4h: Optional[Decimal]
+    trade_count_session: int
+    trade_count_1h: int
+    trade_count_4h: int
+
+
 def floor_to_midnight_utc(ts: datetime) -> datetime:
     """
     Floor timestamp to midnight UTC (00:00:00).
@@ -370,13 +381,7 @@ def parse_trades(filepath: Path, state: VWAPState) -> List[Trade]:
     return trades
 
 
-def write_vwap_output(inst_id: str, minute_ts: datetime, 
-                      vwap_session: Optional[Decimal],
-                      vwap_1h: Optional[Decimal], 
-                      vwap_4h: Optional[Decimal],
-                      trade_count_session: int,
-                      trade_count_1h: int,
-                      trade_count_4h: int):
+def write_vwap_output(inst_id: str, minute_ts: datetime, metrics: VWAPMetrics):
     """
     Write VWAP output to derived JSONL.
     Deduplicates by checking if minute already written.
@@ -409,12 +414,12 @@ def write_vwap_output(inst_id: str, minute_ts: datetime,
         'instId': inst_id,
         'exchange': 'okx',
         'market': 'perp',
-        'vwap_session': str(vwap_session) if vwap_session is not None else None,
-        'vwap_1h': str(vwap_1h) if vwap_1h is not None else None,
-        'vwap_4h': str(vwap_4h) if vwap_4h is not None else None,
-        'trade_count_session': trade_count_session,
-        'trade_count_1h': trade_count_1h,
-        'trade_count_4h': trade_count_4h
+        'vwap_session': str(metrics.vwap_session) if metrics.vwap_session is not None else None,
+        'vwap_1h': str(metrics.vwap_1h) if metrics.vwap_1h is not None else None,
+        'vwap_4h': str(metrics.vwap_4h) if metrics.vwap_4h is not None else None,
+        'trade_count_session': metrics.trade_count_session,
+        'trade_count_1h': metrics.trade_count_1h,
+        'trade_count_4h': metrics.trade_count_4h
     }
     
     # Append to output file
@@ -514,15 +519,18 @@ def process_inst_id(inst_id: str, anchor_time: Optional[str] = None):
             vwap_4h = window_4h.calculate_vwap()
             
             # Write output
+            metrics = VWAPMetrics(
+                vwap_session=vwap_session,
+                vwap_1h=vwap_1h,
+                vwap_4h=vwap_4h,
+                trade_count_session=window_session.get_trade_count(),
+                trade_count_1h=window_1h.get_trade_count(),
+                trade_count_4h=window_4h.get_trade_count()
+            )
             write_vwap_output(
                 inst_id,
                 trade_minute,
-                vwap_session,
-                vwap_1h,
-                vwap_4h,
-                window_session.get_trade_count(),
-                window_1h.get_trade_count(),
-                window_4h.get_trade_count()
+                metrics
             )
             
             vwap_outputs += 1


### PR DESCRIPTION
🎯 **What:** 
The `write_vwap_output` function inside `VWAP/vwap_calculator.py` had a code health issue where it was receiving too many arguments (8 arguments, 6 of which were specific metrics). A new dataclass `VWAPMetrics` was defined to encapsulate `vwap_session`, `vwap_1h`, `vwap_4h`, `trade_count_session`, `trade_count_1h`, and `trade_count_4h`. The function signature and caller were refactored to use this dataclass.

💡 **Why:** 
Passing 8 arguments to a function reduces readability and makes it harder to maintain and test. Encapsulating related parameters into a dataclass simplifies the signature, logically groups related variables together, and makes it trivial to pass additional metrics in the future without modifying the function signature.

✅ **Verification:** 
Verified the syntax using `python -m py_compile VWAP/vwap_calculator.py` and `flake8 VWAP/vwap_calculator.py --select=E9,F63,F7,F82`. Ensured that `from dataclasses import dataclass` was already imported at the top of the file. Removed accidental `__pycache__` artifacts to maintain repository hygiene.

✨ **Result:** 
The `write_vwap_output` function is now cleaner with only 3 arguments. The `VWAPMetrics` object properly acts as a container for related calculation output points. Behavior is completely preserved.

---
*PR created automatically by Jules for task [6752506383470751234](https://jules.google.com/task/6752506383470751234) started by @MattRbear*

## Summary by Sourcery

Refactor VWAP output handling to encapsulate related metrics in a dedicated data structure.

Enhancements:
- Introduce a VWAPMetrics dataclass to group VWAP values and trade counts.
- Simplify write_vwap_output by replacing multiple metric arguments with a single VWAPMetrics parameter.
- Update VWAP processing flow to construct and pass VWAPMetrics instances when writing outputs.