### PR TITLE
🔒 fix: Securely load Coinalyze API key using python-dotenv

### DIFF
--- a/coinayalze_bot/coinalyze_bot.py
+++ b/coinayalze_bot/coinalyze_bot.py
@@ -11,6 +11,7 @@ import json
 import requests
 import logging
 from datetime import datetime, timedelta
+from dotenv import load_dotenv
 from pathlib import Path
 from typing import Dict, List, Optional
 
@@ -372,20 +373,10 @@ class CoinalyzeBot:
 
 def load_api_key() -> Optional[str]:
     """Load API key from environment or env file."""
-    # Try environment variable first
-    api_key = os.getenv('COINALYZE_API_KEY')
+    # Load environment variables from a local .env file if present
+    load_dotenv()
     
-    if not api_key:
-        # Try loading from env file
-        env_file = Path(__file__).parent.parent.parent.parent / 'OneDrive' / 'Desktop' / 'all env.txt'
-        if env_file.exists():
-            with open(env_file, 'r') as f:
-                for line in f:
-                    if line.startswith('COINALYZE_API_KEY='):
-                        api_key = line.split('=')[1].strip()
-                        break
-    
-    return api_key
+    return os.getenv('COINALYZE_API_KEY')
 
 
 if __name__ == "__main__":

--- a/coinayalze_bot/requirements.txt
+++ b/coinayalze_bot/requirements.txt
@@ -1,3 +1,4 @@
 requests>=2.31.0
 python-dateutil
 pathlib
+python-dotenv>=1.0.0


### PR DESCRIPTION
🎯 **What:** Removed the hardcoded fallback absolute file path used for loading the `COINALYZE_API_KEY` in `coinalyze_bot.py`. Replaced it with the secure, standard approach of using `load_dotenv()` from the `python-dotenv` package.
⚠️ **Risk:** The previous approach hardcoded a sensitive absolute path pointing to a personal desktop file (`OneDrive/Desktop/all env.txt`). If the project was shared or if other developers ran the script, they could unintentionally commit or rely on hardcoded paths, or inadvertently expose personal directory structures.
🛡️ **Solution:** Integrated `python-dotenv` to load the `.env` file securely, ensuring credentials are not tied to hardcoded file paths and that the code aligns with Twelve-Factor App methodology for configuration management. Added the missing dependency to `requirements.txt`.

---
*PR created automatically by Jules for task [11406447235909807509](https://jules.google.com/task/11406447235909807509) started by @MattRbear*

## Summary by Sourcery

Load the Coinalyze API key from environment variables using python-dotenv instead of a hardcoded local file path.

Bug Fixes:
- Avoid relying on a hardcoded absolute file path for loading the COINALYZE_API_KEY by using environment variables populated via python-dotenv.

Build:
- Add python-dotenv as a dependency in requirements.txt to support loading configuration from a .env file.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only how `COINALYZE_API_KEY` is sourced, replacing a hardcoded local file fallback with `.env` loading; runtime impact is limited to startup configuration if the key isn’t set.
> 
> **Overview**
> Switches `load_api_key()` to call `load_dotenv()` and read `COINALYZE_API_KEY` from the environment, removing the previous fallback that read from a hardcoded absolute path to a local secrets file.
> 
> Adds `python-dotenv` to `requirements.txt` to support `.env`-based configuration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2e532243ca9ddca051e1076dcfb972d9f9ce039. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->