### PR TITLE
🧹 Refactor VWAP output arguments into dataclass

### DIFF
--- a/VWAP/vwap_calculator.py
+++ b/VWAP/vwap_calculator.py
@@ -95,6 +95,17 @@ class VWAPState:
     last_session_date: Optional[str]  # YYYY-MM-DD for session tracking
 
 
+@dataclass
+class VWAPMetrics:
+    """VWAP metrics for a specific minute."""
+    vwap_session: Optional[Decimal]
+    vwap_1h: Optional[Decimal]
+    vwap_4h: Optional[Decimal]
+    trade_count_session: int
+    trade_count_1h: int
+    trade_count_4h: int
+
+
 def floor_to_midnight_utc(ts: datetime) -> datetime:
     """
     Floor timestamp to midnight UTC (00:00:00).
@@ -370,13 +381,7 @@ def parse_trades(filepath: Path, state: VWAPState) -> List[Trade]:
     return trades
 
 
-def write_vwap_output(inst_id: str, minute_ts: datetime, 
-                      vwap_session: Optional[Decimal],
-                      vwap_1h: Optional[Decimal], 
-                      vwap_4h: Optional[Decimal],
-                      trade_count_session: int,
-                      trade_count_1h: int,
-                      trade_count_4h: int):
+def write_vwap_output(inst_id: str, minute_ts: datetime, metrics: VWAPMetrics):
     """
     Write VWAP output to derived JSONL.
     Deduplicates by checking if minute already written.
@@ -409,12 +414,12 @@ def write_vwap_output(inst_id: str, minute_ts: datetime,
         'instId': inst_id,
         'exchange': 'okx',
         'market': 'perp',
-        'vwap_session': str(vwap_session) if vwap_session is not None else None,
-        'vwap_1h': str(vwap_1h) if vwap_1h is not None else None,
-        'vwap_4h': str(vwap_4h) if vwap_4h is not None else None,
-        'trade_count_session': trade_count_session,
-        'trade_count_1h': trade_count_1h,
-        'trade_count_4h': trade_count_4h
+        'vwap_session': str(metrics.vwap_session) if metrics.vwap_session is not None else None,
+        'vwap_1h': str(metrics.vwap_1h) if metrics.vwap_1h is not None else None,
+        'vwap_4h': str(metrics.vwap_4h) if metrics.vwap_4h is not None else None,
+        'trade_count_session': metrics.trade_count_session,
+        'trade_count_1h': metrics.trade_count_1h,
+        'trade_count_4h': metrics.trade_count_4h
     }
     
     # Append to output file
@@ -513,16 +518,20 @@ def process_inst_id(inst_id: str, anchor_time: Optional[str] = None):
             vwap_1h = window_1h.calculate_vwap()
             vwap_4h = window_4h.calculate_vwap()
             
+            metrics = VWAPMetrics(
+                vwap_session=vwap_session,
+                vwap_1h=vwap_1h,
+                vwap_4h=vwap_4h,
+                trade_count_session=window_session.get_trade_count(),
+                trade_count_1h=window_1h.get_trade_count(),
+                trade_count_4h=window_4h.get_trade_count()
+            )
+
             # Write output
             write_vwap_output(
                 inst_id,
                 trade_minute,
-                vwap_session,
-                vwap_1h,
-                vwap_4h,
-                window_session.get_trade_count(),
-                window_1h.get_trade_count(),
-                window_4h.get_trade_count()
+                metrics
             )
             
             vwap_outputs += 1


### PR DESCRIPTION
🎯 **What:** Refactored the `write_vwap_output` function in `VWAP/vwap_calculator.py` to accept a `VWAPMetrics` dataclass instead of 6 individual metrics parameters.
💡 **Why:** This improves the maintainability and readability of the codebase by resolving the "Too many arguments" code health issue. It groups related data conceptually into a single object.
✅ **Verification:** Ran `python -m py_compile` and `flake8` to ensure no syntax errors or linter violations were introduced. The module currently lacks an automated test suite.
✨ **Result:** A cleaner function signature and caller code in `process_inst_id`, with identical dictionary output formatting preserved.

---
*PR created automatically by Jules for task [12859612849468109311](https://jules.google.com/task/12859612849468109311) started by @MattRbear*

## Summary by Sourcery

Refactor VWAP output handling to group related metrics into a single dataclass passed to the writer function.

Enhancements:
- Introduce a VWAPMetrics dataclass to encapsulate VWAP values and trade counts for a minute.
- Update write_vwap_output and its caller to use the VWAPMetrics object instead of multiple metric arguments, keeping output formatting unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that only changes how VWAP/trade-count metrics are passed into `write_vwap_output`, with the serialized JSONL output schema intended to remain identical.
> 
> **Overview**
> Refactors VWAP output writing to pass a single `VWAPMetrics` dataclass into `write_vwap_output` instead of six separate VWAP/trade-count arguments.
> 
> Updates `process_inst_id` to construct `VWAPMetrics` from the calculated VWAPs and window trade counts, and uses the new object fields when serializing the per-minute JSONL record.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3039296ba15d4fc6321be7e17a3a0b88019f8c71. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->