### PR TITLE
🧹 [Code Health] Remove unused timezone import in VWAP calculator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.py[cod]
+*.log
+.env
+.pytest_cache/

--- a/VWAP/vwap_calculator.py
+++ b/VWAP/vwap_calculator.py
@@ -21,7 +21,7 @@ import json
 import logging
 from pathlib import Path
 from decimal import Decimal, getcontext
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 from typing import List, Dict, Optional
 from dataclasses import dataclass
 from collections import deque


### PR DESCRIPTION
🎯 **What:** Removed the unused `timezone` import from `datetime` in `VWAP/vwap_calculator.py` and added a standard `.gitignore` file.
💡 **Why:** Static analysis identified the import as unused. Removing dead code improves readability and code health. Adding a `.gitignore` ensures build artifacts like `__pycache__` are excluded from version control.
✅ **Verification:** Verified syntax using `python -m py_compile VWAP/vwap_calculator.py` and linted with `flake8 --select=E9,F63,F7,F82`. Ran tests with `PYTHONPATH=. pytest`.
✨ **Result:** Cleaner codebase with improved maintainability and better repository hygiene.

---
*PR created automatically by Jules for task [7878315444042885381](https://jules.google.com/task/7878315444042885381) started by @MattRbear*

## Summary by Sourcery

Clean up the VWAP calculator module and repository by removing dead code and adding standard ignore rules.

Enhancements:
- Remove an unused timezone import from the VWAP calculator to improve code health.

Chores:
- Add a standard .gitignore to exclude Python artifacts and other generated files from version control.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk cleanup: adds ignore rules for common Python artifacts and removes an unused `timezone` import, with no functional logic changes.
> 
> **Overview**
> Improves repo hygiene by adding a `.gitignore` to exclude common Python artifacts (`__pycache__`, `*.pyc`, logs, `.env`, `.pytest_cache`).
> 
> Cleans up `VWAP/vwap_calculator.py` by removing the unused `timezone` import from `datetime`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4168b836a5739cb5ba267c446ed218898076e2e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->