### PR TITLE
🧪 [testing improvement description] Add tests for extract_nova_chat

### DIFF
--- a/tests/test_extract_nova_chat.py
+++ b/tests/test_extract_nova_chat.py
@@ -1,0 +1,70 @@
+import pytest
+from pathlib import Path
+from unittest.mock import patch
+import sys
+import os
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from extract_nova_chat import safe_read_text
+
+def test_safe_read_text_success(tmp_path):
+    """Test successful reading with default utf-8 encoding."""
+    test_file = tmp_path / "test.txt"
+    test_file.write_text("hello world", encoding="utf-8")
+
+    result = safe_read_text(test_file)
+    assert result == "hello world"
+
+@patch('extract_nova_chat.Path.read_text')
+def test_safe_read_text_fallback_encoding(mock_read_text):
+    """Test that it falls back to other encodings if the first one raises an exception."""
+    # Raise Exception for the first two encodings, then succeed on the third
+    mock_read_text.side_effect = [
+        Exception("Failed utf-8"),
+        Exception("Failed utf-16"),
+        "hello world fallback"
+    ]
+
+    dummy_path = Path("dummy.txt")
+    result = safe_read_text(dummy_path)
+
+    assert result == "hello world fallback"
+    assert mock_read_text.call_count == 3
+    # Check the encodings that were called
+    mock_read_text.assert_any_call(encoding='utf-8', errors='replace')
+    mock_read_text.assert_any_call(encoding='utf-16', errors='replace')
+    mock_read_text.assert_any_call(encoding='latin-1', errors='replace')
+
+@patch('extract_nova_chat.Path.read_text')
+def test_safe_read_text_all_encodings_fail(mock_read_text, caplog):
+    """Test when all encodings fail to read the file."""
+    # Mock read_text to always raise an exception
+    mock_read_text.side_effect = Exception("Mocked read error")
+
+    dummy_path = Path("dummy.txt")
+    result = safe_read_text(dummy_path)
+
+    assert result is None
+    # Verify it tried all 4 encodings ('utf-8', 'utf-16', 'latin-1', 'cp1252')
+    assert mock_read_text.call_count == 4
+
+    # Verify the warning was logged
+    assert "Could not read file with any encoding" in caplog.text
+
+
+from extract_nova_chat import strip_html
+
+def test_strip_html_normal():
+    """Test normal HTML stripping."""
+    assert strip_html("<p>Hello <b>world</b>!</p>") == "Hello world !"
+
+def test_strip_html_edge_case():
+    """Test edge cases where unescaped angle brackets cause text to be stripped."""
+    # This intentionally documents the current exact behavior mentioned in memory.
+    # HTML unescape makes &lt; into < and &gt; into >
+    # Then the regex <[^>]+> strips everything in between
+    text = "Math: 5 &lt; 10 and 10 &gt; 5"
+    # unescaped: Math: 5 < 10 and 10 > 5
+    # regex matches "< 10 and 10 >" and removes it
+    assert strip_html(text) == "Math: 5 5"


### PR DESCRIPTION
🎯 **What:** Added tests for the `safe_read_text` and `strip_html` functions in `extract_nova_chat.py`. The `safe_read_text` test covers the happy path (successful read with default encoding and successful read with fallback encoding), and the error path where all tested encodings fail to read the file. The `strip_html` test documents its current expected behavior with edge cases, as mentioned in project instructions.

📊 **Coverage:**
- `safe_read_text_success`: Asserts that `safe_read_text` successfully reads and decodes a file using the default UTF-8 encoding.
- `safe_read_text_fallback_encoding`: Asserts that `safe_read_text` successfully reads and decodes a file using one of the fallback encodings when previous ones fail, mocking the exception correctly.
- `safe_read_text_all_encodings_fail`: Asserts that `safe_read_text` properly handles failure scenarios by catching read errors across all specified encodings, logging a warning, and returning `None`.
- `strip_html_normal` and `strip_html_edge_case`: Tests `strip_html` against normal input, and explicitly asserts its exact parsing limitations handling unescaped angle brackets.

✨ **Result:** Enhanced the test suite coverage and overall reliability by securing missing edge cases for file input operations.

---
*PR created automatically by Jules for task [14732210102378593139](https://jules.google.com/task/14732210102378593139) started by @MattRbear*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only change that doesn’t modify runtime logic, but it locks in current `strip_html` edge-case behavior and logging expectations.
> 
> **Overview**
> Adds a new `tests/test_extract_nova_chat.py` module with pytest coverage for `safe_read_text`, including success, encoding fallback order, and the all-encodings-fail path (asserting a warning is logged and `None` is returned).
> 
> Also adds tests for `strip_html` for normal tag stripping and explicitly *documents the current limitation* where unescaped angle brackets can cause content to be removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e911a6007070e0b211080434fc427ce126d6357. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Summary by Sourcery

Add pytest coverage for text reading and HTML stripping utilities in extract_nova_chat.

Tests:
- Add tests for safe_read_text covering default UTF-8 reading, encoding fallback behavior, and all-encodings-fail logging and return value.
- Add tests for strip_html to validate normal tag stripping and document current behavior on inputs with unescaped angle brackets.