### PR TITLE
🧪 test(extract_nova_chat): add missing error path test for safe_read_text

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.py[cod]
+*.log
+.env
+.pytest_cache/

--- a/tests/test_extract_nova_chat.py
+++ b/tests/test_extract_nova_chat.py
@@ -1,0 +1,11 @@
+import pytest
+from unittest.mock import patch
+from pathlib import Path
+from extract_nova_chat import safe_read_text
+
+def test_safe_read_text_error_path():
+    """Test that safe_read_text returns None when all encodings fail."""
+    test_path = Path("dummy_path.txt")
+    with patch("pathlib.Path.read_text", side_effect=Exception("Simulated read error")):
+        result = safe_read_text(test_path)
+    assert result is None


### PR DESCRIPTION
🎯 **What:** Added missing error path testing coverage for the `safe_read_text` utility in `extract_nova_chat.py`. The previous code lacked a dedicated test case that explicitly confirmed the function behaves correctly (returns `None`) when all encoding attempts fail during a file read.

📊 **Coverage:** The new `test_safe_read_text_error_path` strictly simulates an unwritable/unreadable file condition via `unittest.mock.patch` by having `Path.read_text` throw a simulated read error exception.

✨ **Result:** Test coverage for this module is enhanced, guaranteeing that decoding failures will handle gracefully rather than breaking execution. A `.gitignore` file was also formally added to exclude Python bytecode compilation artifacts (`__pycache__`, `*.pyc`).

---
*PR created automatically by Jules for task [2823961953382058273](https://jules.google.com/task/2823961953382058273) started by @MattRbear*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only adds a unit test for `safe_read_text` and a `.gitignore`; no production logic changes, so risk is minimal aside from potential test-environment assumptions about mocking `Path.read_text`.
> 
> **Overview**
> Adds a regression test (`test_safe_read_text_error_path`) that mocks `Path.read_text` to throw and asserts `safe_read_text` returns `None` when all encoding attempts fail.
> 
> Introduces a new `.gitignore` to exclude common Python artifacts (e.g., `__pycache__`, `*.pyc`, `.pytest_cache`, `.env`, `*.log`) from version control.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 764815f6f469d1d203e1aa2f833f8611eb541318. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Summary by Sourcery

Add test coverage for safe_read_text error handling and introduce a repository .gitignore for Python artifacts.

Tests:
- Add a regression test verifying safe_read_text returns None when file reads consistently fail.

Chores:
- Add a .gitignore file to exclude common Python build and environment artifacts from version control.