### PR TITLE
🧪 Add test for detect_wicks high wick logic

### DIFF
--- a/Untouch_Wick/test_wick_detector.py
+++ b/Untouch_Wick/test_wick_detector.py
@@ -1,0 +1,40 @@
+import pytest
+from decimal import Decimal
+from candle_builder import Candle
+from wick_detector import detect_wicks, WickEvent
+
+def test_detect_wicks_high_wick():
+    """
+    Test that detect_wicks correctly identifies an upper wick.
+    We create a candle where high > max(open, close), but low == min(open, close).
+    """
+    candle = Candle(
+        window_start_utc="2023-01-01T00:00:00Z",
+        window_end_utc="2023-01-01T00:01:00Z",
+        instId="BTC-USDT",
+        exchange="OKX",
+        market="PERP",
+        timeframe="1m",
+        open="100.0",
+        high="120.0",
+        low="100.0",
+        close="110.0",
+        volume="10.0",
+        trade_count=5
+    )
+
+    # Body is from 100.0 to 110.0
+    # Upper wick is from 110.0 to 120.0 (size 10.0)
+    # Lower wick is 0.0 since low == min(open, close)
+
+    wicks = detect_wicks(candle, tickSz="0.1")
+
+    assert len(wicks) == 1
+
+    wick = wicks[0]
+    assert wick.wick_type == 'high'
+    assert wick.wick_price == '120.0'
+    assert wick.wick_size == '10.0'
+    assert wick.body_size == '10.0'
+    assert wick.status == 'untouched'
+    assert wick.event_id == 'BTC-USDT|1m|2023-01-01T00:01:00Z|high'


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was a missing unit test for the high/upper wick detection logic inside `Untouch_Wick/wick_detector.py`.
📊 **Coverage:** The test explicitly verifies the happy path when `upper_wick_size > 0` and ensures that exactly one `WickEvent` is generated with a `wick_type` of `'high'` and the appropriately calculated properties (`wick_price`, `wick_size`, `body_size`, and `status`). 
✨ **Result:** Test coverage for `wick_detector.py` is improved, providing a safety net for any future refactoring of the wick size calculation logic.

---
*PR created automatically by Jules for task [2835253018560327285](https://jules.google.com/task/2835253018560327285) started by @MattRbear*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new pytest test file only, with no production logic changes.
> 
> **Overview**
> Adds a new pytest unit test (`test_wick_detector.py`) that constructs a candle with a non-zero upper wick and asserts `detect_wicks` returns exactly one `WickEvent` with the expected `high` wick fields (`wick_price`, `wick_size`, `body_size`, `status`, and `event_id`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9488f817fe9d7666403df22dc4e60e16c6cd13f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Summary by Sourcery

Tests:
- Add pytest coverage for detecting a single high wick with correct wick and body properties when the upper wick is non-zero.